### PR TITLE
Fix RBAC, performance, and operational issues from code review

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,18 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        go:
-          - '1.21'
-          - '1.22'
-          - '1.23'
-          - '1.24'
-          - '1.25'
-          - '1.26'
-
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
+
+      - name: Go vet
+        run: make vet
 
       - name: Go test
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,18 @@
 FROM --platform=$BUILDPLATFORM golang:1.26 AS build
 
-ARG BUILDPLATFORM
 ARG TARGETARCH
 ARG VERSION
 
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN GOOS=linux GOARCH=$TARGETARCH go build -o /bin/argocd-proxy .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH \
+    go build -ldflags="-s -w -X main.version=${VERSION}" -o /bin/argocd-proxy .
 
-FROM golang:1.26
+FROM gcr.io/distroless/static:nonroot
 
 COPY --from=build /bin/argocd-proxy /usr/local/bin/argocd-proxy
 
+USER nonroot:nonroot
 ENTRYPOINT ["/usr/local/bin/argocd-proxy"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An **ArgoCD Proxy** enhances the performance of the ArgoCD list application API 
 
 2. Build the proxy:
    ```bash
-   go build -o argocd-proxy *.go
+   go build -o argocd-proxy .
    ```
 
 3. Deploy to Kubernetes:
@@ -58,17 +58,39 @@ An **ArgoCD Proxy** enhances the performance of the ArgoCD list application API 
          containers:
          - name: argocd-proxy
            image: <your-image>
-           command: ["argocd-proxy"]
+           args:
+           - --redis-addr=<redis-address>
+           - --redis-db=<redis-db-index>
+           - --proxy-backend=<backend-url>
+           ports:
+           - containerPort: 8081
+           livenessProbe:
+             httpGet:
+               path: /healthz
+               port: 8081
+           readinessProbe:
+             httpGet:
+               path: /readyz
+               port: 8081
    ```
 
 4. Run the proxy locally for testing:
    ```bash
-   ./argocd-proxy --redis-address=<redis-address> --redis-db=<redis-db-index> --proxy-backend=<path-to-the-backend>
+   ./argocd-proxy --redis-addr=<redis-address> --redis-db=<redis-db-index> --proxy-backend=<backend-url>
    ```
 
 ## Configuration
 
 - **Flags**:
-  - `--redis-address`: Redis server address.
-  - `--redis-db`: Redis DB index.
-  - `--proxy-backend`: Proxy backend address.
+  - `--redis-addr`: Redis server address (default `localhost:16379`).
+  - `--redis-db`: Redis DB index (default `1`).
+  - `--proxy-backend`: Backend URL for the reverse proxy (default `http://localhost:8080`).
+  - `--listen-addr`: Address the proxy listens on (default `:8081`).
+  - `--namespace`: Namespace where the ArgoCD RBAC ConfigMap lives (default `argocd`).
+  - `--rbac-configmap`: Name of the ArgoCD RBAC ConfigMap (default `argocd-rbac-cm`).
+  - `--rbac-reload-interval`: How often to reload the RBAC ConfigMap; `0` disables periodic reload (default `5m`).
+
+- **Endpoints**:
+  - `/metrics`: Prometheus metrics.
+  - `/healthz`: Liveness probe.
+  - `/readyz`: Readiness probe (checks Redis connectivity).

--- a/main.go
+++ b/main.go
@@ -4,13 +4,17 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
+	"os/signal"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +26,11 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )
+
+const listApplicationsPath = "/api/v1/applications"
+
+// version is set at build time via -ldflags "-X main.version=...".
+var version = "dev"
 
 // Define Prometheus metrics for HTTP request duration (milliseconds) and total request count.
 var requestDuration = prometheus.NewHistogramVec(
@@ -46,6 +55,32 @@ func init() {
 	log.SetOutput(os.Stdout)
 }
 
+// applicationList mirrors the shape of the ArgoCD list applications response.
+type applicationList struct {
+	Items []interface{} `json:"items"`
+}
+
+// rbacPolicy holds the resolved RBAC mappings and allows concurrent reads while
+// the background reloader swaps in fresh mappings.
+type rbacPolicy struct {
+	mu                          sync.RWMutex
+	userToObjectPatternMapping  map[string][]string
+	groupToObjectPatternMapping map[string][]string
+}
+
+func (p *rbacPolicy) get() (map[string][]string, map[string][]string) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return p.userToObjectPatternMapping, p.groupToObjectPatternMapping
+}
+
+func (p *rbacPolicy) set(userMapping, groupMapping map[string][]string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.userToObjectPatternMapping = userMapping
+	p.groupToObjectPatternMapping = groupMapping
+}
+
 func main() {
 	// Register Prometheus metrics
 	prometheus.MustRegister(requestDuration, requestTotal)
@@ -54,6 +89,10 @@ func main() {
 	redisAddr := flag.String("redis-addr", "localhost:16379", "Redis server address")
 	redisDB := flag.Int("redis-db", 1, "Redis database number")
 	proxyBackend := flag.String("proxy-backend", "http://localhost:8080", "Backend URL for reverse proxy")
+	listenAddr := flag.String("listen-addr", ":8081", "Address the proxy listens on")
+	namespace := flag.String("namespace", "argocd", "Namespace where the ArgoCD RBAC ConfigMap lives")
+	rbacConfigMap := flag.String("rbac-configmap", "argocd-rbac-cm", "Name of the ArgoCD RBAC ConfigMap")
+	rbacReloadInterval := flag.Duration("rbac-reload-interval", 5*time.Minute, "How often to reload the RBAC ConfigMap (0 disables periodic reload)")
 
 	// Parse command-line flags
 	flag.Parse()
@@ -65,7 +104,22 @@ func main() {
 		log.Fatalf("Failed to create Kubernetes client: %v", err)
 	}
 
-	userToObjectPatternMapping, groupToObjectPatternMapping := loadRBACPolicyFromConfigMap(clientset, "argocd", "argocd-rbac-cm")
+	// Load the initial RBAC policy. Failure is non-fatal: the proxy stays
+	// fail-open by forwarding requests to the backend, which enforces RBAC.
+	policy := &rbacPolicy{}
+	if userMapping, groupMapping, err := loadRBACPolicyFromConfigMap(clientset, *namespace, *rbacConfigMap); err != nil {
+		log.Errorf("Failed to load initial RBAC policy: %v", err)
+	} else {
+		policy.set(userMapping, groupMapping)
+	}
+
+	// Periodically reload the RBAC policy so ConfigMap changes are picked up
+	// without restarting the proxy.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	if *rbacReloadInterval > 0 {
+		go reloadRBACPolicy(ctx, clientset, *namespace, *rbacConfigMap, *rbacReloadInterval, policy)
+	}
 
 	// Initialize Redis client
 	redisClient := initializeRedis(*redisAddr, *redisDB)
@@ -73,32 +127,66 @@ func main() {
 	// Create a reverse proxy
 	proxy := createReverseProxy(*proxyBackend)
 
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now() // Start measuring time
 
 		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
-		handleRequest(rw, r, proxy, redisClient, userToObjectPatternMapping, groupToObjectPatternMapping)
+		handleRequest(rw, r, proxy, redisClient, policy)
 
-		// Record duration and total request count
+		// Record duration and total request count. The path is normalized to a
+		// bounded set of route templates to avoid Prometheus label cardinality
+		// blowups from per-application paths.
 		duration := float64(time.Since(start).Milliseconds())
 		statusCodeStr := fmt.Sprintf("%d", rw.statusCode)
+		path := normalizePath(r.URL.Path)
 
-		requestTotal.WithLabelValues(r.Method, r.URL.Path, statusCodeStr).Inc()
-		requestDuration.WithLabelValues(r.Method, r.URL.Path, statusCodeStr).Observe(duration)
+		requestTotal.WithLabelValues(r.Method, path, statusCodeStr).Inc()
+		requestDuration.WithLabelValues(r.Method, path, statusCodeStr).Observe(duration)
 	})
 
 	// Expose Prometheus metrics endpoint
-	http.Handle("/metrics", promhttp.Handler())
+	mux.Handle("/metrics", promhttp.Handler())
 
-	log.Println("Proxy server running on :8081")
+	// Liveness and readiness probes for Kubernetes.
+	mux.HandleFunc("/healthz", func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/readyz", func(w http.ResponseWriter, _ *http.Request) {
+		if err := redisClient.Ping().Err(); err != nil {
+			http.Error(w, "redis unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
 	srv := &http.Server{
-		Addr:         ":8081",
-		Handler:      nil,              // default mux
-		ReadTimeout:  0,                // Disable read timeout for long-running connections
-		WriteTimeout: 0,                // Disable write timeout for streaming responses
-		IdleTimeout:  15 * time.Second, // Only applies to idle connections
+		Addr:    *listenAddr,
+		Handler: mux,
+		// ReadTimeout/WriteTimeout are left unset to support long-running
+		// streaming responses, but ReadHeaderTimeout bounds how long a client
+		// may take to send headers, mitigating slowloris-style attacks.
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       15 * time.Second,
 	}
-	log.Fatal(srv.ListenAndServe())
+
+	go func() {
+		log.Infof("Proxy server (version %s) running on %s", version, *listenAddr)
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			log.Fatalf("HTTP server error: %v", err)
+		}
+	}()
+
+	// Wait for a termination signal, then drain in-flight requests.
+	<-ctx.Done()
+	stop()
+	log.Infoln("Shutdown signal received, draining connections...")
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		log.Errorf("Graceful shutdown failed: %v", err)
+	}
+	log.Infoln("Proxy server stopped")
 }
 
 // Custom response writer to capture status codes
@@ -112,20 +200,41 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-func loadRBACPolicyFromConfigMap(clientset *kubernetes.Clientset, namespace, configMapName string) (map[string][]string, map[string][]string) {
+// reloadRBACPolicy reloads the RBAC ConfigMap on a fixed interval until the
+// context is cancelled. The existing policy is retained if a reload fails.
+func reloadRBACPolicy(ctx context.Context, clientset *kubernetes.Clientset, namespace, configMapName string, interval time.Duration, policy *rbacPolicy) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			userMapping, groupMapping, err := loadRBACPolicyFromConfigMap(clientset, namespace, configMapName)
+			if err != nil {
+				log.Errorf("Failed to reload RBAC policy, keeping previous policy: %v", err)
+				continue
+			}
+			policy.set(userMapping, groupMapping)
+			log.Infoln("Reloaded RBAC policy")
+		}
+	}
+}
+
+func loadRBACPolicyFromConfigMap(clientset *kubernetes.Clientset, namespace, configMapName string) (map[string][]string, map[string][]string, error) {
 	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(context.Background(), configMapName, metav1.GetOptions{})
 	if err != nil {
-		log.Errorf("Failed to fetch ConfigMap %s: %v", configMapName, err)
-		return nil, nil
+		return nil, nil, fmt.Errorf("failed to fetch ConfigMap %s/%s: %w", namespace, configMapName, err)
 	}
 
 	policyCSV, ok := cm.Data["policy.csv"]
 	if !ok {
-		log.Errorf("policy.csv not found in ConfigMap %s\n", configMapName)
-		return nil, nil
+		return nil, nil, fmt.Errorf("policy.csv not found in ConfigMap %s/%s", namespace, configMapName)
 	}
 
-	return parsePolicyCSV(policyCSV)
+	userMapping, groupMapping := parsePolicyCSV(policyCSV)
+	return userMapping, groupMapping, nil
 }
 
 func initializeRedis(addr string, db int) *redis.Client {
@@ -157,32 +266,45 @@ func createReverseProxy(target string) *httputil.ReverseProxy {
 		FlushInterval: 100 * time.Millisecond, // Enable periodic flushing for streaming
 		ErrorHandler: func(w http.ResponseWriter, r *http.Request, err error) {
 			if r.Context().Err() == context.Canceled {
-				log.Printf("Client disconnected: %s", r.URL.Path)
+				log.Infof("Client disconnected: %s", r.URL.Path)
 			} else {
-				log.Printf("Proxy error: %v (URL: %s)", err, r.URL.Path)
+				log.Errorf("Proxy error: %v (URL: %s)", err, r.URL.Path)
 			}
 			http.Error(w, "Error during proxying request", http.StatusBadGateway)
 		},
 	}
 }
 
-func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.ReverseProxy, redisClient *redis.Client, userToObjectPatternMapping, groupToObjectPatternMapping map[string][]string) {
+// shouldInterceptListRequest reports whether a request targets the list
+// applications endpoint that the proxy serves from Redis. Only the exact list
+// path is intercepted; single-application reads (e.g. /api/v1/applications/foo)
+// and applicationsets are forwarded to the backend unchanged.
+func shouldInterceptListRequest(r *http.Request) bool {
+	return r.Method == http.MethodGet && r.URL.Path == listApplicationsPath
+}
+
+func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.ReverseProxy, redisClient *redis.Client, policy *rbacPolicy) {
 	token := extractToken(r)
-	if token == "" || (r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/api/v1/applications")) {
+	if token == "" || !shouldInterceptListRequest(r) {
 		proxy.ServeHTTP(w, r)
 		return
 	}
 
 	payload, err := decodeJWTPayload(token)
 	if err != nil {
-		log.Errorf("Failed to decode JWT payload: %v\n", err)
+		log.Errorf("Failed to decode JWT payload: %v", err)
 		proxy.ServeHTTP(w, r)
 		return
 	}
 
+	// TODO(#2): verify the JWT signature (HS256 with the ArgoCD server.secretkey)
+	// before trusting these claims. The claims are currently consumed without
+	// signature verification.
 	email, _ := payload["email"].(string)
-	groups, _ := payload["groups"].([]string)
-	objectPatterns := resolveObjectPatterns(email, groups, userToObjectPatternMapping, groupToObjectPatternMapping)
+	groups := extractGroups(payload)
+
+	userMapping, groupMapping := policy.get()
+	objectPatterns := resolveObjectPatterns(email, groups, userMapping, groupMapping)
 
 	resp := fetchApplicationsFromRedis(redisClient, objectPatterns)
 	if len(resp.Items) == 0 {
@@ -197,8 +319,9 @@ func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.Rever
 
 	w.Header().Set("Content-Type", "application/json")
 	if err := json.NewEncoder(w).Encode(resp); err != nil {
-		log.Printf("Failed to write response: %v", err)
-		proxy.ServeHTTP(w, r)
+		// Headers and a partial body may already be written, so we cannot fall
+		// back to the proxy here; just log the failure.
+		log.Errorf("Failed to write response: %v", err)
 	}
 }
 
@@ -230,6 +353,23 @@ func decodeJWTPayload(token string) (map[string]interface{}, error) {
 	return payload, nil
 }
 
+// extractGroups reads the "groups" claim from a decoded JWT payload. JSON arrays
+// unmarshal into []interface{}, so each element is converted to a string;
+// non-string elements are skipped.
+func extractGroups(payload map[string]interface{}) []string {
+	raw, ok := payload["groups"].([]interface{})
+	if !ok {
+		return nil
+	}
+	groups := make([]string, 0, len(raw))
+	for _, g := range raw {
+		if s, ok := g.(string); ok {
+			groups = append(groups, s)
+		}
+	}
+	return groups
+}
+
 func resolveObjectPatterns(email string, groups []string, userToObjectPatternMapping, groupToObjectPatternMapping map[string][]string) map[string]struct{} {
 	objectPatterns := make(map[string]struct{})
 
@@ -246,18 +386,34 @@ func resolveObjectPatterns(email string, groups []string, userToObjectPatternMap
 	return objectPatterns
 }
 
-func fetchApplicationsFromRedis(redisClient *redis.Client, objectPatterns map[string]struct{}) struct {
-	Items []interface{} `json:"items"`
-} {
-	resp := struct {
-		Items []interface{} `json:"items"`
-	}{Items: []interface{}{}}
+// scanKeys returns all Redis keys matching the given glob pattern using SCAN,
+// which iterates the keyspace in bounded batches instead of blocking the server
+// like KEYS does.
+func scanKeys(redisClient *redis.Client, match string) ([]string, error) {
+	var keys []string
+	var cursor uint64
+	for {
+		batch, next, err := redisClient.Scan(cursor, match, 100).Result()
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, batch...)
+		cursor = next
+		if cursor == 0 {
+			break
+		}
+	}
+	return keys, nil
+}
+
+func fetchApplicationsFromRedis(redisClient *redis.Client, objectPatterns map[string]struct{}) applicationList {
+	resp := applicationList{Items: []interface{}{}}
 
 	var allKeys []string
 	for pattern := range objectPatterns {
-		keys, err := redisClient.Keys(fmt.Sprintf("%s|*", pattern)).Result()
+		keys, err := scanKeys(redisClient, fmt.Sprintf("%s|*", pattern))
 		if err != nil {
-			log.Printf("Failed to fetch keys for pattern %s: %v", pattern, err)
+			log.Errorf("Failed to scan keys for pattern %s: %v", pattern, err)
 			continue
 		}
 		allKeys = append(allKeys, keys...)
@@ -271,7 +427,7 @@ func fetchApplicationsFromRedis(redisClient *redis.Client, objectPatterns map[st
 		}
 		_, err := pipe.Exec()
 		if err != nil && err != redis.Nil {
-			log.Printf("Failed to fetch values for keys: %v", err)
+			log.Errorf("Failed to fetch values for keys: %v", err)
 		}
 
 		for i, cmd := range cmds {
@@ -280,10 +436,10 @@ func fetchApplicationsFromRedis(redisClient *redis.Client, objectPatterns map[st
 				if err := json.Unmarshal([]byte(cmd.Val()), &rawJson); err == nil {
 					resp.Items = append(resp.Items, rawJson)
 				} else {
-					log.Printf("Failed to unmarshal value for key %s: %v", allKeys[i], err)
+					log.Errorf("Failed to unmarshal value for key %s: %v", allKeys[i], err)
 				}
 			} else {
-				log.Printf("Failed to fetch value for key %s: %v", allKeys[i], cmd.Err())
+				log.Errorf("Failed to fetch value for key %s: %v", allKeys[i], cmd.Err())
 			}
 		}
 	}
@@ -335,6 +491,19 @@ func filterApplicationsByClusterAndNamespace(items []interface{}, cluster, names
 		filtered = append(filtered, item)
 	}
 	return filtered
+}
+
+// normalizePath maps a request path to a bounded set of route templates so that
+// Prometheus labels do not explode with per-application paths.
+func normalizePath(path string) string {
+	switch path {
+	case listApplicationsPath, "/metrics", "/healthz", "/readyz":
+		return path
+	}
+	if strings.HasPrefix(path, listApplicationsPath+"/") {
+		return listApplicationsPath + "/:name"
+	}
+	return "other"
 }
 
 func parsePolicyCSV(policyCSV string) (map[string][]string, map[string][]string) {
@@ -394,7 +563,7 @@ func parsePolicyCSV(policyCSV string) (map[string][]string, map[string][]string)
 			objectPattern := fields[4]
 			// effect := field[5]
 
-			if resource == "applications" || resource == "applicationsets" || resource == "logs" || resource == "exec " {
+			if resource == "applications" || resource == "applicationsets" || resource == "logs" || resource == "exec" {
 				objectPattern = strings.TrimSuffix(objectPattern, "/*")
 			}
 

--- a/main_test.go
+++ b/main_test.go
@@ -411,6 +411,112 @@ func TestFilterApplicationsByClusterAndNamespace(t *testing.T) {
 	}
 }
 
+func TestExtractGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  map[string]interface{}
+		expected []string
+	}{
+		{
+			name:     "Groups present as JSON array",
+			payload:  map[string]interface{}{"groups": []interface{}{"group1", "group2"}},
+			expected: []string{"group1", "group2"},
+		},
+		{
+			name:     "Groups missing",
+			payload:  map[string]interface{}{"email": "user@example.com"},
+			expected: nil,
+		},
+		{
+			name:     "Groups with non-string elements are skipped",
+			payload:  map[string]interface{}{"groups": []interface{}{"group1", 42, "group2"}},
+			expected: []string{"group1", "group2"},
+		},
+		{
+			name:     "Empty groups array",
+			payload:  map[string]interface{}{"groups": []interface{}{}},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractGroups(tt.payload)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("extractGroups() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractGroupsFromDecodedJWT(t *testing.T) {
+	// Guard against the regression where a JSON array claim was asserted as
+	// []string directly, which always fails and silently drops all groups.
+	token := createTestJWT(map[string]interface{}{
+		"email":  "user@example.com",
+		"groups": []string{"team-a", "team-b"},
+	})
+
+	payload, err := decodeJWTPayload(token)
+	if err != nil {
+		t.Fatalf("decodeJWTPayload() unexpected error: %v", err)
+	}
+
+	groups := extractGroups(payload)
+	expected := []string{"team-a", "team-b"}
+	if !reflect.DeepEqual(groups, expected) {
+		t.Errorf("extractGroups() = %v, want %v", groups, expected)
+	}
+}
+
+func TestShouldInterceptListRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		expected bool
+	}{
+		{"GET list endpoint is intercepted", http.MethodGet, "/api/v1/applications", true},
+		{"single application is not intercepted", http.MethodGet, "/api/v1/applications/myapp", false},
+		{"applicationsets is not intercepted", http.MethodGet, "/api/v1/applicationsets", false},
+		{"resource subpath is not intercepted", http.MethodGet, "/api/v1/applications/myapp/resource-tree", false},
+		{"non-GET list endpoint is not intercepted", http.MethodPost, "/api/v1/applications", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			if got := shouldInterceptListRequest(req); got != tt.expected {
+				t.Errorf("shouldInterceptListRequest(%s %s) = %v, want %v", tt.method, tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestNormalizePath(t *testing.T) {
+	tests := []struct {
+		path     string
+		expected string
+	}{
+		{"/api/v1/applications", "/api/v1/applications"},
+		{"/metrics", "/metrics"},
+		{"/healthz", "/healthz"},
+		{"/readyz", "/readyz"},
+		{"/api/v1/applications/myapp", "/api/v1/applications/:name"},
+		{"/api/v1/applications/myapp/resource-tree", "/api/v1/applications/:name"},
+		{"/api/v1/clusters", "other"},
+		{"/", "other"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := normalizePath(tt.path); got != tt.expected {
+				t.Errorf("normalizePath(%q) = %q, want %q", tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
 func compareMaps(a, b map[string]interface{}) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary

Addresses correctness, security, performance, and operational issues surfaced in a code review of the proxy. JWT signature verification (item #2) is intentionally deferred and left as a `TODO`.

## Behavioral / correctness fixes
- **Group RBAC was completely broken**: the `groups` JWT claim was asserted as `[]string`, but JSON arrays unmarshal into `[]interface{}`, so the assertion always failed and every group-based rule was silently dropped. Now parsed via `extractGroups()`, with a regression test covering the real decode→extract path.
- **Only intercept the exact `GET /api/v1/applications` list endpoint** — single-application reads (`/api/v1/applications/<name>`), subpaths, and `applicationsets` were being served the wrong (`{items:[...]}`) shape; they now forward to the backend unchanged.
- **Fix `"exec "` RBAC resource match** (trailing space meant it never matched).

## Performance / scalability
- **Replace blocking Redis `KEYS` with cursor-based `SCAN`** — `KEYS` blocks the server and is O(N) over the keyspace, the opposite of this tool's goal.
- **Bound Prometheus path label cardinality** via `normalizePath()` route templates (raw `URL.Path` created a new series per application).
- **Reload the RBAC ConfigMap periodically** (`--rbac-reload-interval`, default 5m) instead of only at startup; the previous policy is retained if a reload fails.

## Operational
- Graceful shutdown on SIGINT/SIGTERM (drains in-flight requests).
- `/healthz` and `/readyz` probes (readyz pings Redis).
- `ReadHeaderTimeout` to mitigate slowloris (streaming-friendly timeouts kept).
- Avoid double-write when response encoding fails.
- `--listen-addr`, `--namespace`, `--rbac-configmap` flags replace hardcoded values.

## Build / CI / Docker
- **Dockerfile**: `gcr.io/distroless/static:nonroot` runtime, static CGO-free build, non-root user, dependency layer caching (was the full ~800MB `golang:1.26` running as root).
- **CI**: derive Go version from `go.mod` (removes the 1.21–1.25 matrix that conflicts with `go 1.26.0`), add `go vet`, bump `checkout@v4`/`setup-go@v5`.
- **README**: fix build command (`*.go`→`.`), fix wrong flag names (`--redis-address`→`--redis-addr`), document new flags/endpoints, add probes to the deployment example.

## Deferred
- **JWT signature verification (#2)** — left as a `TODO` per maintainer decision; claims are consumed without signature verification for now.

## Testing
- `make all` (test + race build), `go vet ./...`, and `gofmt -l` all clean.
- Added tests: `TestExtractGroups`, `TestExtractGroupsFromDecodedJWT`, `TestShouldInterceptListRequest`, `TestNormalizePath`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)