### PR TITLE
Fix RBAC correctness bugs (groups parsing, exact list path, exec match)

### DIFF
--- a/main.go
+++ b/main.go
@@ -23,6 +23,8 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
+const listApplicationsPath = "/api/v1/applications"
+
 // Define Prometheus metrics for HTTP request duration (milliseconds) and total request count.
 var requestDuration = prometheus.NewHistogramVec(
 	prometheus.HistogramOpts{
@@ -166,9 +168,17 @@ func createReverseProxy(target string) *httputil.ReverseProxy {
 	}
 }
 
+// shouldInterceptListRequest reports whether a request targets the list
+// applications endpoint that the proxy serves from Redis. Only the exact list
+// path is intercepted; single-application reads (e.g. /api/v1/applications/foo)
+// and applicationsets are forwarded to the backend unchanged.
+func shouldInterceptListRequest(r *http.Request) bool {
+	return r.Method == http.MethodGet && r.URL.Path == listApplicationsPath
+}
+
 func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.ReverseProxy, redisClient *redis.Client, userToObjectPatternMapping, groupToObjectPatternMapping map[string][]string) {
 	token := extractToken(r)
-	if token == "" || (r.Method != http.MethodGet || !strings.HasPrefix(r.URL.Path, "/api/v1/applications")) {
+	if token == "" || !shouldInterceptListRequest(r) {
 		proxy.ServeHTTP(w, r)
 		return
 	}
@@ -181,7 +191,7 @@ func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.Rever
 	}
 
 	email, _ := payload["email"].(string)
-	groups, _ := payload["groups"].([]string)
+	groups := extractGroups(payload)
 	objectPatterns := resolveObjectPatterns(email, groups, userToObjectPatternMapping, groupToObjectPatternMapping)
 
 	resp := fetchApplicationsFromRedis(redisClient, objectPatterns)
@@ -200,6 +210,23 @@ func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.Rever
 		log.Printf("Failed to write response: %v", err)
 		proxy.ServeHTTP(w, r)
 	}
+}
+
+// extractGroups reads the "groups" claim from a decoded JWT payload. JSON arrays
+// unmarshal into []interface{}, so each element is converted to a string;
+// non-string elements are skipped.
+func extractGroups(payload map[string]interface{}) []string {
+	raw, ok := payload["groups"].([]interface{})
+	if !ok {
+		return nil
+	}
+	groups := make([]string, 0, len(raw))
+	for _, g := range raw {
+		if s, ok := g.(string); ok {
+			groups = append(groups, s)
+		}
+	}
+	return groups
 }
 
 func extractToken(r *http.Request) string {
@@ -394,7 +421,7 @@ func parsePolicyCSV(policyCSV string) (map[string][]string, map[string][]string)
 			objectPattern := fields[4]
 			// effect := field[5]
 
-			if resource == "applications" || resource == "applicationsets" || resource == "logs" || resource == "exec " {
+			if resource == "applications" || resource == "applicationsets" || resource == "logs" || resource == "exec" {
 				objectPattern = strings.TrimSuffix(objectPattern, "/*")
 			}
 

--- a/main_test.go
+++ b/main_test.go
@@ -411,6 +411,88 @@ func TestFilterApplicationsByClusterAndNamespace(t *testing.T) {
 	}
 }
 
+func TestExtractGroups(t *testing.T) {
+	tests := []struct {
+		name     string
+		payload  map[string]interface{}
+		expected []string
+	}{
+		{
+			name:     "Groups present as JSON array",
+			payload:  map[string]interface{}{"groups": []interface{}{"group1", "group2"}},
+			expected: []string{"group1", "group2"},
+		},
+		{
+			name:     "Groups missing",
+			payload:  map[string]interface{}{"email": "user@example.com"},
+			expected: nil,
+		},
+		{
+			name:     "Groups with non-string elements are skipped",
+			payload:  map[string]interface{}{"groups": []interface{}{"group1", 42, "group2"}},
+			expected: []string{"group1", "group2"},
+		},
+		{
+			name:     "Empty groups array",
+			payload:  map[string]interface{}{"groups": []interface{}{}},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := extractGroups(tt.payload)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("extractGroups() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExtractGroupsFromDecodedJWT(t *testing.T) {
+	// Guard against the regression where a JSON array claim was asserted as
+	// []string directly, which always fails and silently drops all groups.
+	token := createTestJWT(map[string]interface{}{
+		"email":  "user@example.com",
+		"groups": []string{"team-a", "team-b"},
+	})
+
+	payload, err := decodeJWTPayload(token)
+	if err != nil {
+		t.Fatalf("decodeJWTPayload() unexpected error: %v", err)
+	}
+
+	groups := extractGroups(payload)
+	expected := []string{"team-a", "team-b"}
+	if !reflect.DeepEqual(groups, expected) {
+		t.Errorf("extractGroups() = %v, want %v", groups, expected)
+	}
+}
+
+func TestShouldInterceptListRequest(t *testing.T) {
+	tests := []struct {
+		name     string
+		method   string
+		path     string
+		expected bool
+	}{
+		{"GET list endpoint is intercepted", http.MethodGet, "/api/v1/applications", true},
+		{"single application is not intercepted", http.MethodGet, "/api/v1/applications/myapp", false},
+		{"applicationsets is not intercepted", http.MethodGet, "/api/v1/applicationsets", false},
+		{"resource subpath is not intercepted", http.MethodGet, "/api/v1/applications/myapp/resource-tree", false},
+		{"non-GET list endpoint is not intercepted", http.MethodPost, "/api/v1/applications", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, tt.path, nil)
+			if got := shouldInterceptListRequest(req); got != tt.expected {
+				t.Errorf("shouldInterceptListRequest(%s %s) = %v, want %v", tt.method, tt.path, got, tt.expected)
+			}
+		})
+	}
+}
+
 func compareMaps(a, b map[string]interface{}) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
Part 1/5 of splitting #69 into focused PRs.

## Fixes
- **Group RBAC was completely broken.** The `groups` JWT claim was asserted as `[]string`, but JSON arrays unmarshal into `[]interface{}`, so the assertion always failed and every group-based rule was silently dropped. Now parsed via `extractGroups()`.
- **Only intercept the exact `GET /api/v1/applications` list endpoint.** Prefix matching also captured single-application reads (`/api/v1/applications/<name>`), subpaths, and `applicationsets`, which were then served the wrong `{items:[...]}` shape. Extracted into `shouldInterceptListRequest()`.
- **Fix `"exec "` RBAC resource match** — the trailing space meant it never matched.

## Tests
- `TestExtractGroups`, `TestExtractGroupsFromDecodedJWT` (covers the real decode→extract path), `TestShouldInterceptListRequest`.
- `go vet`, `go test`, `gofmt -l` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)