### PR TITLE
Harden Docker image and CI, fix README

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,25 +11,18 @@ on:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        go:
-          - '1.21'
-          - '1.22'
-          - '1.23'
-          - '1.24'
-          - '1.25'
-          - '1.26'
-
     runs-on: ubuntu-latest
     steps:
       - name: Check out code into the Go module directory
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Set up Go ${{ matrix.go }}
-        uses: actions/setup-go@v4
+      - name: Set up Go
+        uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go }}
+          go-version-file: go.mod
+
+      - name: Go vet
+        run: make vet
 
       - name: Go test
         run: make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
 FROM --platform=$BUILDPLATFORM golang:1.26 AS build
 
-ARG BUILDPLATFORM
 ARG TARGETARCH
-ARG VERSION
 
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
 COPY . .
-RUN GOOS=linux GOARCH=$TARGETARCH go build -o /bin/argocd-proxy .
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=$TARGETARCH \
+    go build -ldflags="-s -w" -o /bin/argocd-proxy .
 
-FROM golang:1.26
+FROM gcr.io/distroless/static:nonroot
 
 COPY --from=build /bin/argocd-proxy /usr/local/bin/argocd-proxy
 
+USER nonroot:nonroot
 ENTRYPOINT ["/usr/local/bin/argocd-proxy"]

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ An **ArgoCD Proxy** enhances the performance of the ArgoCD list application API 
 
 2. Build the proxy:
    ```bash
-   go build -o argocd-proxy *.go
+   go build -o argocd-proxy .
    ```
 
 3. Deploy to Kubernetes:
@@ -63,12 +63,12 @@ An **ArgoCD Proxy** enhances the performance of the ArgoCD list application API 
 
 4. Run the proxy locally for testing:
    ```bash
-   ./argocd-proxy --redis-address=<redis-address> --redis-db=<redis-db-index> --proxy-backend=<path-to-the-backend>
+   ./argocd-proxy --redis-addr=<redis-address> --redis-db=<redis-db-index> --proxy-backend=<backend-url>
    ```
 
 ## Configuration
 
 - **Flags**:
-  - `--redis-address`: Redis server address.
-  - `--redis-db`: Redis DB index.
-  - `--proxy-backend`: Proxy backend address.
+  - `--redis-addr`: Redis server address (default `localhost:16379`).
+  - `--redis-db`: Redis DB index (default `1`).
+  - `--proxy-backend`: Backend URL for the reverse proxy (default `http://localhost:8080`).


### PR DESCRIPTION
Part 5/5 of splitting #69 into focused PRs. **Touches only Dockerfile, CI, and README — no `main.go`, so it merges independently with zero conflicts.**

## Changes
- **Dockerfile**: build a static (`CGO_ENABLED=0`) binary and run it from `gcr.io/distroless/static:nonroot` as a non-root user, instead of shipping the full `golang:1.26` toolchain image running as root. Adds dependency-layer caching via `go mod download`.
- **CI**: derive the Go version from `go.mod` (removes the 1.21–1.25 matrix that conflicts with the `go 1.26.0` directive), add a `go vet` step, bump `actions/checkout@v4` and `actions/setup-go@v5`.
- **README**: fix the build command (`go build .`) and correct the flag names (`--redis-addr`, not `--redis-address`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)