### PR TITLE
Add ETag / 304 Not Modified to the application list

### DIFF
--- a/main.go
+++ b/main.go
@@ -8,11 +8,14 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"hash/fnv"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
 	"os"
 	"os/signal"
+	"sort"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -249,7 +252,39 @@ func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.Rever
 		items = filterRawByClusterAndNamespace(items, cluster, namespace)
 	}
 
-	w.Header().Set("Content-Type", "application/json")
+	serveCachedList(w, r, items)
+}
+
+// computeETag returns a strong, quoted ETag over the application list body, so an
+// unchanged response can be answered with 304 Not Modified. fetchRawApplications
+// sorts its keys, so the body — and therefore this ETag — is stable across
+// requests when the underlying data has not changed.
+func computeETag(items [][]byte) string {
+	h := fnv.New64a()
+	h.Write([]byte(`{"items":[`))
+	for i, raw := range items {
+		if i > 0 {
+			h.Write([]byte{','})
+		}
+		h.Write(raw)
+	}
+	h.Write([]byte("]}"))
+	return `"` + strconv.FormatUint(h.Sum64(), 16) + `"`
+}
+
+// serveCachedList writes the application list with an ETag. A request whose
+// If-None-Match matches the current ETag gets 304 Not Modified with no body,
+// saving the (potentially large) response transfer when nothing has changed.
+func serveCachedList(w http.ResponseWriter, r *http.Request, items [][]byte) {
+	etag := computeETag(items)
+	h := w.Header()
+	h.Set("ETag", etag)
+	h.Set("Content-Type", "application/json")
+
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
 	writeApplicationList(w, items)
 }
 
@@ -373,6 +408,9 @@ func fetchRawApplications(redisClient *redis.Client, objectPatterns map[string]s
 	if len(allKeys) == 0 {
 		return nil
 	}
+	// Redis SCAN returns keys in an unspecified order; sort so the response body
+	// — and the ETag computed from it — are deterministic across requests.
+	sort.Strings(allKeys)
 
 	pipe := redisClient.Pipeline()
 	cmds := make([]*redis.StringCmd, len(allKeys))

--- a/main_test.go
+++ b/main_test.go
@@ -551,3 +551,71 @@ func compareMaps(a, b map[string]interface{}) bool {
 	}
 	return true
 }
+
+func TestComputeETag(t *testing.T) {
+	a := [][]byte{[]byte(`{"metadata":{"name":"a"}}`), []byte(`{"metadata":{"name":"b"}}`)}
+
+	e := computeETag(a)
+	if computeETag(a) != e {
+		t.Error("etag not stable for identical items")
+	}
+	// Different content -> different etag.
+	b := [][]byte{[]byte(`{"metadata":{"name":"a"}}`), []byte(`{"metadata":{"name":"c"}}`)}
+	if computeETag(b) == e {
+		t.Error("etag collided for different items")
+	}
+	// Must be a quoted strong ETag.
+	if len(e) < 2 || e[0] != '"' || e[len(e)-1] != '"' {
+		t.Errorf("etag must be quoted, got %s", e)
+	}
+	// Empty items still produce a stable etag.
+	if computeETag(nil) != computeETag([][]byte{}) {
+		t.Error("empty etag not stable")
+	}
+}
+
+func TestServeCachedList(t *testing.T) {
+	items := [][]byte{[]byte(`{"metadata":{"name":"a"}}`), []byte(`{"metadata":{"name":"b"}}`)}
+
+	// First request: 200 with ETag + full body.
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/applications", nil)
+	rec := httptest.NewRecorder()
+	serveCachedList(rec, req, items)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	et := rec.Header().Get("ETag")
+	if et == "" {
+		t.Fatal("missing ETag")
+	}
+	if rec.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("missing Content-Type")
+	}
+	if got, want := rec.Body.String(), `{"items":[{"metadata":{"name":"a"}},{"metadata":{"name":"b"}}]}`; got != want {
+		t.Errorf("body = %s, want %s", got, want)
+	}
+
+	// Conditional request with matching ETag: 304, empty body, ETag still present.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/v1/applications", nil)
+	req2.Header.Set("If-None-Match", et)
+	rec2 := httptest.NewRecorder()
+	serveCachedList(rec2, req2, items)
+	if rec2.Code != http.StatusNotModified {
+		t.Fatalf("status = %d, want 304", rec2.Code)
+	}
+	if rec2.Body.Len() != 0 {
+		t.Errorf("304 body must be empty, got %d bytes", rec2.Body.Len())
+	}
+	if rec2.Header().Get("ETag") != et {
+		t.Errorf("304 should still carry the ETag")
+	}
+
+	// Stale If-None-Match -> 200 with body.
+	req3 := httptest.NewRequest(http.MethodGet, "/api/v1/applications", nil)
+	req3.Header.Set("If-None-Match", `"stale"`)
+	rec3 := httptest.NewRecorder()
+	serveCachedList(rec3, req3, items)
+	if rec3.Code != http.StatusOK {
+		t.Errorf("stale If-None-Match should be 200, got %d", rec3.Code)
+	}
+}


### PR DESCRIPTION
## What

Adds HTTP conditional GET to the proxied `GET /api/v1/applications`:

- The response carries a strong **`ETag`** (FNV-64a hash of the `{"items":[...]}` body).
- A request whose **`If-None-Match`** equals the current ETag gets **`304 Not Modified`** with no body.

## Why

For a browser over WAN the dominant cost of the list endpoint is transferring the
(uncompressed) payload. When nothing has changed since the last load, a 304 lets
the browser reuse its cached copy and **skip the body transfer entirely**.

## Notes

- `fetchRawApplications` now **sorts the Redis keys** before fetching, so the body
  order — and thus the ETag — is deterministic across requests when the data is
  unchanged (Redis `SCAN` returns keys in an unspecified order, which would
  otherwise make the ETag flap and never match).
- The ETag is content-derived, so it still reflects cluster/namespace-filtered
  results correctly. 304 skips the body build's compression/transfer but not the
  Redis read (in-cluster and cheap); a revision-counter ETag that also skips the
  Redis read would require the watcher to maintain a revision and is left out of
  scope.

## Test

New `TestComputeETag` (stable/sensitive/quoted) and `TestServeCachedList`
(200+ETag, matching `If-None-Match` → 304 empty, stale → 200). `go build`,
`go vet`, `go test ./...`, `gofmt -l .` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)