### PR TITLE
Verify JWT signature before trusting session claims

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,8 @@ An **ArgoCD Proxy** enhances the performance of the ArgoCD list application API 
   - `--redis-addr`: Redis server address (default `localhost:16379`).
   - `--redis-db`: Redis DB index (default `1`).
   - `--proxy-backend`: Backend URL for the reverse proxy (default `http://localhost:8080`).
+  - `--namespace`: Namespace where the ArgoCD RBAC ConfigMap and Secret live (default `argocd`).
+  - `--rbac-configmap`: Name of the ArgoCD RBAC ConfigMap (default `argocd-rbac-cm`).
+  - `--argocd-secret`: Name of the ArgoCD Secret holding the session-signing key, `server.secretkey` (default `argocd-secret`).
+
+- **Session token verification**: Requests to the cached `/api/v1/applications` list endpoint carry an ArgoCD session JWT, which the proxy verifies (HS256) against `server.secretkey` from the ArgoCD Secret before trusting any of its claims. The proxy's ServiceAccount needs `get` on that Secret in addition to the RBAC ConfigMap; if the key can't be loaded, the cached fast path is disabled and every request falls back to the real ArgoCD backend, which still enforces its own RBAC.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/go-redis/redis/v7 v7.4.1
+	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sirupsen/logrus v1.9.4
 	k8s.io/apimachinery v0.36.2

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/go-redis/redis/v7 v7.4.1 h1:PASvf36gyUpr2zdOUS/9Zqc80GbM+9BDyiJSJDDOr
 github.com/go-redis/redis/v7 v7.4.1/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/google/gnostic-models v0.7.1 h1:SisTfuFKJSKM5CPZkffwi6coztzzeYUhc3v4yxLWH8c=

--- a/main.go
+++ b/main.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"context"
-	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -25,10 +24,16 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/go-redis/redis/v7"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	log "github.com/sirupsen/logrus"
 )
+
+// argoCDSecretKeyField is the data key in the ArgoCD secret holding the HMAC
+// key ArgoCD uses to sign session JWTs (both local-user and SSO sessions go
+// through ArgoCD's own session manager, which always signs with this key).
+const argoCDSecretKeyField = "server.secretkey"
 
 const listApplicationsPath = "/api/v1/applications"
 
@@ -66,6 +71,7 @@ func main() {
 	listenAddr := flag.String("listen-addr", ":8081", "Address the proxy listens on")
 	namespace := flag.String("namespace", "argocd", "Namespace where the ArgoCD RBAC ConfigMap lives")
 	rbacConfigMap := flag.String("rbac-configmap", "argocd-rbac-cm", "Name of the ArgoCD RBAC ConfigMap")
+	argocdSecret := flag.String("argocd-secret", "argocd-secret", "Name of the ArgoCD Secret holding the session-signing key (server.secretkey)")
 
 	// Parse command-line flags
 	flag.Parse()
@@ -78,6 +84,10 @@ func main() {
 	}
 
 	userToObjectPatternMapping, groupToObjectPatternMapping := loadRBACPolicyFromConfigMap(clientset, *namespace, *rbacConfigMap)
+	signingKey := loadSigningKeyFromSecret(clientset, *namespace, *argocdSecret)
+	if len(signingKey) == 0 {
+		log.Errorf("No JWT signing key available; the cached list-applications fast path is disabled and all requests will be proxied to the backend")
+	}
 
 	// Initialize Redis client
 	redisClient := initializeRedis(*redisAddr, *redisDB)
@@ -90,7 +100,7 @@ func main() {
 		start := time.Now() // Start measuring time
 
 		rw := &responseWriter{ResponseWriter: w, statusCode: http.StatusOK}
-		handleRequest(rw, r, proxy, redisClient, userToObjectPatternMapping, groupToObjectPatternMapping)
+		handleRequest(rw, r, proxy, redisClient, signingKey, userToObjectPatternMapping, groupToObjectPatternMapping)
 
 		// Record duration and total request count
 		duration := float64(time.Since(start).Milliseconds())
@@ -175,6 +185,25 @@ func loadRBACPolicyFromConfigMap(clientset *kubernetes.Clientset, namespace, con
 	return parsePolicyCSV(policyCSV)
 }
 
+// loadSigningKeyFromSecret fetches the HMAC key ArgoCD uses to sign session
+// JWTs from the ArgoCD Secret. Without this key the proxy cannot verify the
+// authenticity of a token's claims, so callers must treat a nil/empty result
+// as "verification unavailable" rather than trusting unverified claims.
+func loadSigningKeyFromSecret(clientset *kubernetes.Clientset, namespace, secretName string) []byte {
+	secret, err := clientset.CoreV1().Secrets(namespace).Get(context.Background(), secretName, metav1.GetOptions{})
+	if err != nil {
+		log.Errorf("Failed to fetch Secret %s: %v", secretName, err)
+		return nil
+	}
+
+	key, ok := secret.Data[argoCDSecretKeyField]
+	if !ok || len(key) == 0 {
+		log.Errorf("%s not found in Secret %s", argoCDSecretKeyField, secretName)
+		return nil
+	}
+	return key
+}
+
 func initializeRedis(addr string, db int) *redis.Client {
 	client := redis.NewClient(&redis.Options{
 		Addr:        addr,
@@ -221,16 +250,16 @@ func shouldInterceptListRequest(r *http.Request) bool {
 	return r.Method == http.MethodGet && r.URL.Path == listApplicationsPath
 }
 
-func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.ReverseProxy, redisClient *redis.Client, userToObjectPatternMapping, groupToObjectPatternMapping map[string][]string) {
+func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.ReverseProxy, redisClient *redis.Client, signingKey []byte, userToObjectPatternMapping, groupToObjectPatternMapping map[string][]string) {
 	token := extractToken(r)
 	if token == "" || !shouldInterceptListRequest(r) {
 		proxy.ServeHTTP(w, r)
 		return
 	}
 
-	payload, err := decodeJWTPayload(token)
+	payload, err := verifyAndDecodeJWT(token, signingKey)
 	if err != nil {
-		log.Errorf("Failed to decode JWT payload: %v\n", err)
+		log.Errorf("Failed to verify JWT: %v\n", err)
 		proxy.ServeHTTP(w, r)
 		return
 	}
@@ -336,22 +365,27 @@ func extractToken(r *http.Request) string {
 	return ""
 }
 
-func decodeJWTPayload(token string) (map[string]interface{}, error) {
-	parts := strings.Split(token, ".")
-	if len(parts) < 2 {
-		return nil, fmt.Errorf("invalid token format")
+// verifyAndDecodeJWT verifies the token's HMAC signature against signingKey
+// and returns its claims. The signing method is pinned to HS256 so a forged
+// token cannot switch to "none" or otherwise smuggle an unverified signature
+// past this check (the classic JWT algorithm-confusion attack); the standard
+// exp/nbf/iat claims are validated by the underlying library when present.
+func verifyAndDecodeJWT(token string, signingKey []byte) (map[string]interface{}, error) {
+	if len(signingKey) == 0 {
+		return nil, fmt.Errorf("no signing key configured")
 	}
 
-	payloadBytes, err := base64.RawURLEncoding.DecodeString(parts[1])
+	claims := jwt.MapClaims{}
+	parsed, err := jwt.ParseWithClaims(token, claims, func(*jwt.Token) (interface{}, error) {
+		return signingKey, nil
+	}, jwt.WithValidMethods([]string{"HS256"}))
 	if err != nil {
-		return nil, fmt.Errorf("failed to decode payload: %v", err)
+		return nil, fmt.Errorf("failed to verify token: %w", err)
 	}
-
-	var payload map[string]interface{}
-	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
-		return nil, fmt.Errorf("failed to unmarshal payload: %v", err)
+	if !parsed.Valid {
+		return nil, fmt.Errorf("invalid token")
 	}
-	return payload, nil
+	return claims, nil
 }
 
 func resolveObjectPatterns(email string, groups []string, userToObjectPatternMapping, groupToObjectPatternMapping map[string][]string) map[string]struct{} {

--- a/main_test.go
+++ b/main_test.go
@@ -7,8 +7,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
+
+	"github.com/golang-jwt/jwt/v5"
 )
+
+const testSigningKey = "test-signing-key"
 
 func TestParsePolicyCSV(t *testing.T) {
 	tests := []struct {
@@ -267,36 +272,58 @@ func TestExtractToken(t *testing.T) {
 	}
 }
 
-func TestDecodeJWTPayload(t *testing.T) {
+func TestVerifyAndDecodeJWT(t *testing.T) {
+	signingKey := []byte(testSigningKey)
+
 	tests := []struct {
 		name           string
 		token          string
+		signingKey     []byte
 		expected       map[string]interface{}
 		expectingError bool
 	}{
 		{
-			name:           "Valid JWT Token",
+			name:           "Valid signed token",
 			token:          createTestJWT(map[string]interface{}{"email": "test@example.com", "role": "admin"}),
+			signingKey:     signingKey,
 			expected:       map[string]interface{}{"email": "test@example.com", "role": "admin"},
 			expectingError: false,
 		},
 		{
-			name:           "Invalid JWT Token Format",
-			token:          "invalid.token",
-			expected:       nil,
+			name:           "Wrong signing key is rejected",
+			token:          createTestJWT(map[string]interface{}{"email": "test@example.com"}),
+			signingKey:     []byte("a-different-key"),
 			expectingError: true,
 		},
 		{
-			name:           "Invalid Payload Encoding",
-			token:          "header." + base64.RawURLEncoding.EncodeToString([]byte("invalid payload")) + ".signature",
-			expected:       nil,
+			name:           "No signing key configured",
+			token:          createTestJWT(map[string]interface{}{"email": "test@example.com"}),
+			signingKey:     nil,
+			expectingError: true,
+		},
+		{
+			name:           "alg=none token is rejected",
+			token:          unsignedNoneAlgToken(map[string]interface{}{"email": "attacker@example.com", "role": "admin"}),
+			signingKey:     signingKey,
+			expectingError: true,
+		},
+		{
+			name:           "Tampered payload is rejected",
+			token:          tamperPayload(createTestJWT(map[string]interface{}{"email": "test@example.com"})),
+			signingKey:     signingKey,
+			expectingError: true,
+		},
+		{
+			name:           "Malformed token",
+			token:          "not-a-jwt",
+			signingKey:     signingKey,
 			expectingError: true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			payload, err := decodeJWTPayload(tt.token)
+			payload, err := verifyAndDecodeJWT(tt.token, tt.signingKey)
 
 			if tt.expectingError && err == nil {
 				t.Errorf("Expected an error but got none")
@@ -313,11 +340,32 @@ func TestDecodeJWTPayload(t *testing.T) {
 	}
 }
 
+// createTestJWT signs payload with testSigningKey using HS256, mirroring how
+// ArgoCD signs its own session tokens.
 func createTestJWT(payload map[string]interface{}) string {
-	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"HS256","typ":"JWT"}`))
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims(payload))
+	signed, err := token.SignedString([]byte(testSigningKey))
+	if err != nil {
+		panic(err)
+	}
+	return signed
+}
+
+// unsignedNoneAlgToken builds a token asserting alg=none with an empty
+// signature, the classic JWT algorithm-confusion forgery.
+func unsignedNoneAlgToken(payload map[string]interface{}) string {
+	header := base64.RawURLEncoding.EncodeToString([]byte(`{"alg":"none","typ":"JWT"}`))
 	payloadBytes, _ := json.Marshal(payload)
 	encodedPayload := base64.RawURLEncoding.EncodeToString(payloadBytes)
-	return header + "." + encodedPayload + ".signature"
+	return header + "." + encodedPayload + "."
+}
+
+// tamperPayload swaps in a different payload while keeping the original
+// header and signature, simulating an attacker editing claims in place.
+func tamperPayload(token string) string {
+	parts := strings.Split(token, ".")
+	tampered := base64.RawURLEncoding.EncodeToString([]byte(`{"email":"attacker@example.com"}`))
+	return parts[0] + "." + tampered + "." + parts[2]
 }
 
 func TestFilterRawByClusterAndNamespace(t *testing.T) {
@@ -504,9 +552,9 @@ func TestExtractGroupsFromDecodedJWT(t *testing.T) {
 		"groups": []string{"team-a", "team-b"},
 	})
 
-	payload, err := decodeJWTPayload(token)
+	payload, err := verifyAndDecodeJWT(token, []byte(testSigningKey))
 	if err != nil {
-		t.Fatalf("decodeJWTPayload() unexpected error: %v", err)
+		t.Fatalf("verifyAndDecodeJWT() unexpected error: %v", err)
 	}
 
 	groups := extractGroups(payload)


### PR DESCRIPTION
## Summary
- The cached `/api/v1/applications` list fast path previously decoded a JWT's `email`/`groups` claims without checking the signature, so a forged token could claim any identity and bypass RBAC filtering without ever reaching the real ArgoCD backend.
- Verify each token's HS256 signature against ArgoCD's session-signing key (`server.secretkey`, read from the `argocd-secret` Secret) before trusting its claims, pinning the accepted algorithm to block `alg=none`-style forgeries.
- If the signing key can't be loaded, the fast path is disabled and requests fall back to the real backend, which still enforces its own RBAC.
- Adds a new `--argocd-secret` flag (default `argocd-secret`) and documents the additional `get` permission the proxy's ServiceAccount needs.

## Test plan
- [x] `go vet ./...`
- [x] `go test ./...` (new tests: valid signature, wrong key, missing key, `alg=none` rejection, tampered payload, malformed token)
- [x] `go build -race .`
