### PR TITLE
Add commit/PR conventions for AI-assisted changes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,8 @@
+# Commit & PR conventions
+
+- Do not leave any indication that a commit or PR was written with Claude Code:
+  no `Co-Authored-By: Claude ...` trailer, no `Claude-Session:` link, no
+  "Generated with Claude Code" footer, and no mention of Claude/Anthropic in
+  commit messages or PR titles/descriptions.
+- Use the repo owner's identity for commit authorship (`JenTing Hsiao
+  <hsiaoairplane@gmail.com>`), matching existing history.


### PR DESCRIPTION
## Summary
- Adds `CLAUDE.md` documenting that commits/PRs in this repo should not carry Claude Code attribution (no co-author trailer, session link, or generated-with footer) and should use the repo owner's identity for authorship.