### PR TITLE
Parse RBAC policy.csv fields with quote-aware tokenization

### DIFF
--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"context"
+	"encoding/csv"
 	"encoding/json"
 	"errors"
 	"flag"
@@ -503,6 +504,23 @@ func filterRawByClusterAndNamespace(items [][]byte, cluster, namespace string) [
 	return filtered
 }
 
+// parseCSVLine tokenizes a single ArgoCD RBAC policy.csv line into its
+// comma-separated fields, honoring quoted values so commas inside a quoted
+// field (e.g. an LDAP group DN like "cn=foo,ou=bar,dc=example,dc=com") are
+// not treated as field separators.
+func parseCSVLine(line string) ([]string, error) {
+	reader := csv.NewReader(strings.NewReader(line))
+	reader.TrimLeadingSpace = true
+	fields, err := reader.Read()
+	if err != nil {
+		return nil, err
+	}
+	for i := range fields {
+		fields[i] = strings.TrimSpace(fields[i])
+	}
+	return fields, nil
+}
+
 func parsePolicyCSV(policyCSV string) (map[string][]string, map[string][]string) {
 	userToRoleMapping := make(map[string][]string)
 	groupToRoleMapping := make(map[string][]string)
@@ -522,10 +540,13 @@ func parsePolicyCSV(policyCSV string) (map[string][]string, map[string][]string)
 			continue
 		}
 
-		// Split the line into fields
-		fields := strings.Split(line, ",")
-		for i := range fields {
-			fields[i] = strings.TrimSpace(fields[i]) // Trim spaces around each field
+		// Split the line into fields, respecting quoted values so that
+		// fields containing literal commas (e.g. LDAP group DNs) parse
+		// as a single field instead of being split apart.
+		fields, err := parseCSVLine(line)
+		if err != nil {
+			log.Warnf("Skipping malformed RBAC policy line %q: %v", line, err)
+			continue
 		}
 
 		// Process "g" entries (group-role mappings)

--- a/main_test.go
+++ b/main_test.go
@@ -127,6 +127,19 @@ func TestParsePolicyCSV(t *testing.T) {
 			expectedUserToObjectPatternMapping:  map[string][]string{},
 			expectedGroupToObjectPatternMapping: map[string][]string{},
 		},
+		{
+			name: "Group name with quoted embedded comma is parsed as a single field",
+			policyCSV: `
+				p, team-delta-readonly, applications, get, delta-*, allow
+				g, "cn=delta-readonly,ou=groups,dc=example,dc=com", team-delta-readonly
+			`,
+			expectedUserToObjectPatternMapping: map[string][]string{},
+			expectedGroupToObjectPatternMapping: map[string][]string{
+				"cn=delta-readonly,ou=groups,dc=example,dc=com": {
+					"delta-*",
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

`policy.csv` parsing used naive comma-splitting (`strings.Split(line, ",")`), which breaks on any field containing a literal comma — e.g. an LDAP group DN like `"CN=Team Alpha,OU=Groups,DC=example,DC=com"`. Replaced with an `encoding/csv`-based parser (`parseCSVLine`) so quoted fields are tokenized correctly.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (added a case to `TestParsePolicyCSV` covering a quoted group name with embedded commas)
- [x] `make fmt && make vet && make test && make build`
