### PR TITLE
Add RBAC deny-effect support and role-to-role inheritance

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,5 @@ An **ArgoCD Proxy** enhances the performance of the ArgoCD list application API 
   - `--argocd-secret`: Name of the ArgoCD Secret holding the session-signing key, `server.secretkey` (default `argocd-secret`).
 
 - **Session token verification**: Requests to the cached `/api/v1/applications` list endpoint carry an ArgoCD session JWT, which the proxy verifies (HS256) against `server.secretkey` from the ArgoCD Secret before trusting any of its claims. The proxy's ServiceAccount needs `get` on that Secret in addition to the RBAC ConfigMap; if the key can't be loaded, the cached fast path is disabled and every request falls back to the real ArgoCD backend, which still enforces its own RBAC.
+
+- **RBAC policy semantics**: `policy.csv` is parsed with the same effect rule ArgoCD uses — a `deny` rule for an object always overrides any `allow` rule for that object, regardless of which role or group granted the allow. Role-to-role inheritance (`g, role:child, role:parent`) is resolved transitively, and fields are parsed with quote-aware CSV parsing so values containing commas (e.g. LDAP group DNs) are handled correctly.

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26.0
 
 require (
 	github.com/go-redis/redis/v7 v7.4.1
+	github.com/gobwas/glob v0.2.3
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/prometheus/client_golang v1.23.2
 	github.com/sirupsen/logrus v1.9.4

--- a/go.sum
+++ b/go.sum
@@ -61,6 +61,8 @@ github.com/go-redis/redis/v7 v7.4.1 h1:PASvf36gyUpr2zdOUS/9Zqc80GbM+9BDyiJSJDDOr
 github.com/go-redis/redis/v7 v7.4.1/go.mod h1:JDNMw23GTyLNC4GZu9njt15ctBQVn7xjRfnwdHj/Dcg=
 github.com/go-task/slim-sprig/v3 v3.0.0 h1:sUs3vkvUymDpBKi3qH1YSqBQk9+9D/8M2mN1vB6EwHI=
 github.com/go-task/slim-sprig/v3 v3.0.0/go.mod h1:W848ghGpv3Qj3dhTPRyJypKRiqCdHZiAzKg9hl15HA8=
+github.com/gobwas/glob v0.2.3 h1:A4xDbljILXROh+kObIiy5kIaPYD8e96x1tgBhUI5J+Y=
+github.com/gobwas/glob v0.2.3/go.mod h1:d3Ez4x06l9bZtSvzIay5+Yzi0fmZzPgnTbPcKjJAkT8=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=

--- a/main.go
+++ b/main.go
@@ -14,6 +14,7 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"path"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +38,26 @@ import (
 const argoCDSecretKeyField = "server.secretkey"
 
 const listApplicationsPath = "/api/v1/applications"
+
+// rbacPolicy holds the object glob patterns a subject (user or group) is
+// granted, split by ArgoCD policy effect. A deny match always overrides an
+// allow match for the same object, so the two are kept separate rather than
+// merged into a single pattern list.
+type rbacPolicy struct {
+	allow []string
+	deny  []string
+}
+
+// allowedResources are the ArgoCD RBAC resource types that gate visibility of
+// items in the cached application list. Rules for other resource types (e.g.
+// "clusters", "certificates") don't affect which applications are returned by
+// this proxy, so they are ignored by parsePolicyCSV.
+var allowedResources = map[string]bool{
+	"applications":    true,
+	"applicationsets": true,
+	"logs":            true,
+	"exec":            true,
+}
 
 // Define Prometheus metrics for HTTP request duration (milliseconds) and total request count.
 var requestDuration = prometheus.NewHistogramVec(
@@ -170,7 +191,7 @@ func (rw *responseWriter) WriteHeader(code int) {
 	rw.ResponseWriter.WriteHeader(code)
 }
 
-func loadRBACPolicyFromConfigMap(clientset *kubernetes.Clientset, namespace, configMapName string) (map[string][]string, map[string][]string) {
+func loadRBACPolicyFromConfigMap(clientset *kubernetes.Clientset, namespace, configMapName string) (map[string]rbacPolicy, map[string]rbacPolicy) {
 	cm, err := clientset.CoreV1().ConfigMaps(namespace).Get(context.Background(), configMapName, metav1.GetOptions{})
 	if err != nil {
 		log.Errorf("Failed to fetch ConfigMap %s: %v", configMapName, err)
@@ -251,7 +272,7 @@ func shouldInterceptListRequest(r *http.Request) bool {
 	return r.Method == http.MethodGet && r.URL.Path == listApplicationsPath
 }
 
-func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.ReverseProxy, redisClient *redis.Client, signingKey []byte, userToObjectPatternMapping, groupToObjectPatternMapping map[string][]string) {
+func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.ReverseProxy, redisClient *redis.Client, signingKey []byte, userToObjectPatternMapping, groupToObjectPatternMapping map[string]rbacPolicy) {
 	token := extractToken(r)
 	if token == "" || !shouldInterceptListRequest(r) {
 		proxy.ServeHTTP(w, r)
@@ -267,12 +288,16 @@ func handleRequest(w http.ResponseWriter, r *http.Request, proxy *httputil.Rever
 
 	email, _ := payload["email"].(string)
 	groups := extractGroups(payload)
-	objectPatterns := resolveObjectPatterns(email, groups, userToObjectPatternMapping, groupToObjectPatternMapping)
+	allowPatterns, denyPatterns := resolveObjectPatterns(email, groups, userToObjectPatternMapping, groupToObjectPatternMapping)
 
-	items := fetchRawApplications(redisClient, objectPatterns)
+	items := fetchRawApplications(redisClient, allowPatterns)
 	if len(items) == 0 {
 		proxy.ServeHTTP(w, r)
 		return
+	}
+
+	if len(denyPatterns) > 0 {
+		items = excludeDenied(items, denyPatterns)
 	}
 
 	queryParams := r.URL.Query()
@@ -389,20 +414,30 @@ func verifyAndDecodeJWT(token string, signingKey []byte) (map[string]interface{}
 	return claims, nil
 }
 
-func resolveObjectPatterns(email string, groups []string, userToObjectPatternMapping, groupToObjectPatternMapping map[string][]string) map[string]struct{} {
-	objectPatterns := make(map[string]struct{})
+// resolveObjectPatterns unions the allow and deny object patterns granted to a
+// user directly and through their groups. ArgoCD's policy effect rule is
+// "some(where (p.eft == allow)) && !some(where (p.eft == deny))", i.e. a deny
+// match always overrides any allow match for the same object, regardless of
+// which subject (user or group) it came from; the deny patterns returned here
+// are applied as a post-fetch filter by the caller to honor that rule even
+// when a deny pattern doesn't textually overlap an allow pattern.
+func resolveObjectPatterns(email string, groups []string, userToObjectPatternMapping, groupToObjectPatternMapping map[string]rbacPolicy) (map[string]struct{}, []string) {
+	allow := make(map[string]struct{})
+	var deny []string
 
-	for _, pattern := range userToObjectPatternMapping[email] {
-		objectPatterns[pattern] = struct{}{}
-	}
-
-	for _, group := range groups {
-		for _, pattern := range groupToObjectPatternMapping[group] {
-			objectPatterns[pattern] = struct{}{}
+	addPolicy := func(policy rbacPolicy) {
+		for _, pattern := range policy.allow {
+			allow[pattern] = struct{}{}
 		}
+		deny = append(deny, policy.deny...)
 	}
 
-	return objectPatterns
+	addPolicy(userToObjectPatternMapping[email])
+	for _, group := range groups {
+		addPolicy(groupToObjectPatternMapping[group])
+	}
+
+	return allow, deny
 }
 
 // scanKeys returns all Redis keys matching the given glob pattern using SCAN,
@@ -504,10 +539,56 @@ func filterRawByClusterAndNamespace(items [][]byte, cluster, namespace string) [
 	return filtered
 }
 
-// parseCSVLine tokenizes a single ArgoCD RBAC policy.csv line into its
-// comma-separated fields, honoring quoted values so commas inside a quoted
-// field (e.g. an LDAP group DN like "cn=foo,ou=bar,dc=example,dc=com") are
-// not treated as field separators.
+// matchesObjectPattern reports whether object (typically "<project>/<name>")
+// matches an ArgoCD-style glob pattern. "*" is treated as matching everything,
+// including objects containing "/", which path.Match would otherwise reject
+// since "/" is a segment separator for it.
+func matchesObjectPattern(pattern, object string) bool {
+	if pattern == "*" {
+		return true
+	}
+	matched, err := path.Match(pattern, object)
+	return err == nil && matched
+}
+
+// excludeDenied removes applications matching any deny pattern from items.
+// Each item is unmarshaled just enough to read its project and name, mirroring
+// the approach filterRawByClusterAndNamespace uses for the destination fields.
+func excludeDenied(items [][]byte, denyPatterns []string) [][]byte {
+	filtered := make([][]byte, 0, len(items))
+	for _, raw := range items {
+		var app struct {
+			Metadata struct {
+				Name string `json:"name"`
+			} `json:"metadata"`
+			Spec struct {
+				Project string `json:"project"`
+			} `json:"spec"`
+		}
+		if err := json.Unmarshal(raw, &app); err != nil {
+			continue
+		}
+		object := app.Spec.Project + "/" + app.Metadata.Name
+
+		denied := false
+		for _, pattern := range denyPatterns {
+			if matchesObjectPattern(pattern, object) {
+				denied = true
+				break
+			}
+		}
+		if denied {
+			continue
+		}
+
+		filtered = append(filtered, raw)
+	}
+	return filtered
+}
+
+// parseCSVLine parses a single RBAC policy line into trimmed fields, using
+// encoding/csv so quoted fields may safely contain commas (e.g. an LDAP group
+// DN like "CN=Team Alpha,OU=Groups,DC=example,DC=com").
 func parseCSVLine(line string) ([]string, error) {
 	reader := csv.NewReader(strings.NewReader(line))
 	reader.TrimLeadingSpace = true
@@ -521,100 +602,128 @@ func parseCSVLine(line string) ([]string, error) {
 	return fields, nil
 }
 
-func parsePolicyCSV(policyCSV string) (map[string][]string, map[string][]string) {
-	userToRoleMapping := make(map[string][]string)
-	groupToRoleMapping := make(map[string][]string)
+// resolveReachableRoles returns every role transitively reachable from
+// subject by following "g" (subject-to-role) edges, supporting ArgoCD's
+// role-to-role inheritance (e.g. "g, role:org-admin, role:admin"). Cycles are
+// guarded against via the visited set so a misconfigured policy can't cause
+// infinite recursion.
+func resolveReachableRoles(subject string, edges map[string][]string) []string {
+	visited := make(map[string]bool)
+	var roles []string
 
-	roleToObjectPatternMapping := make(map[string][]string)
+	var visit func(string)
+	visit = func(s string) {
+		for _, role := range edges[s] {
+			if visited[role] {
+				continue
+			}
+			visited[role] = true
+			roles = append(roles, role)
+			visit(role)
+		}
+	}
+	visit(subject)
+
+	return roles
+}
+
+// parsePolicyCSV parses an ArgoCD RBAC policy.csv document into per-subject
+// allow/deny object pattern policies, one map for users (subjects containing
+// "@") and one for groups. "g" lines are also used to build a generic
+// subject-to-role graph so role-to-role inheritance (e.g.
+// "g, role:org-admin, role:admin") is resolved transitively, not just one
+// level deep. Only "p" rules for resource types that affect application
+// visibility (allowedResources) contribute object patterns; rules for other
+// resource types (e.g. "clusters") are ignored.
+func parsePolicyCSV(policyCSV string) (map[string]rbacPolicy, map[string]rbacPolicy) {
+	// subjectEdges records every "g, subject, role" edge. It doubles as the
+	// graph resolveReachableRoles walks for role-to-role inheritance, since a
+	// role can itself be the subject of another "g" line.
+	subjectEdges := make(map[string][]string)
+
+	seenUser := make(map[string]bool)
+	seenGroup := make(map[string]bool)
+	var userSubjects, groupSubjects []string
+
+	roleToPolicyMapping := make(map[string]rbacPolicy)
 	// default rules
 	// - role:admin: unrestricted access to all objects
 	// - role:readonly: read-only access to all objects
-	roleToObjectPatternMapping["role:admin"] = []string{"*"}
-	roleToObjectPatternMapping["role:readonly"] = []string{"*"}
+	roleToPolicyMapping["role:admin"] = rbacPolicy{allow: []string{"*"}}
+	roleToPolicyMapping["role:readonly"] = rbacPolicy{allow: []string{"*"}}
 
-	lines := strings.Split(policyCSV, "\n")
-	for _, line := range lines {
-		// Ignore empty lines and comments
-		line = strings.TrimSpace(line)
+	scanner := bufio.NewScanner(strings.NewReader(policyCSV))
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
 		if line == "" || strings.HasPrefix(line, "#") {
 			continue
 		}
 
-		// Split the line into fields, respecting quoted values so that
-		// fields containing literal commas (e.g. LDAP group DNs) parse
-		// as a single field instead of being split apart.
 		fields, err := parseCSVLine(line)
 		if err != nil {
-			log.Warnf("Skipping malformed RBAC policy line %q: %v", line, err)
+			log.Errorf("Failed to parse RBAC policy line %q: %v", line, err)
 			continue
 		}
 
-		// Process "g" entries (group-role mappings)
-		if fields[0] == "g" && len(fields) >= 3 {
+		switch {
+		case fields[0] == "g" && len(fields) >= 3:
 			userOrGroup := fields[1]
 			role := fields[2]
+			subjectEdges[userOrGroup] = append(subjectEdges[userOrGroup], role)
 
 			if strings.Contains(userOrGroup, "@") {
-				// Process user-role mappings
-				user := userOrGroup
-				if _, exists := userToRoleMapping[user]; !exists {
-					// Initialize the role in the groupToRoleMapping map if it doesn't exist
-					userToRoleMapping[user] = []string{}
+				if !seenUser[userOrGroup] {
+					seenUser[userOrGroup] = true
+					userSubjects = append(userSubjects, userOrGroup)
 				}
-				userToRoleMapping[user] = append(userToRoleMapping[user], role)
-			} else {
-				// Process group-role mappings
-				group := userOrGroup
-				if _, exists := groupToRoleMapping[group]; !exists {
-					// Initialize the role in the groupToRoleMapping map if it doesn't exist
-					groupToRoleMapping[group] = []string{}
-				}
-				groupToRoleMapping[group] = append(groupToRoleMapping[group], role)
+			} else if !seenGroup[userOrGroup] {
+				seenGroup[userOrGroup] = true
+				groupSubjects = append(groupSubjects, userOrGroup)
 			}
-		}
 
-		// Process "p" entries (role-resource mappings)
-		if fields[0] == "p" && len(fields) >= 5 {
+		case fields[0] == "p" && len(fields) >= 5:
 			role := fields[1]
 			resource := fields[2]
 			// action := fields[3]
 			objectPattern := fields[4]
-			// effect := field[5]
-
-			if resource == "applications" || resource == "applicationsets" || resource == "logs" || resource == "exec" {
-				objectPattern = strings.TrimSuffix(objectPattern, "/*")
+			effect := "allow"
+			if len(fields) >= 6 && fields[5] != "" {
+				effect = strings.ToLower(fields[5])
 			}
 
-			if _, exists := roleToObjectPatternMapping[role]; !exists {
-				// Initialize the role in the roleToObjectPatternMapping map if it doesn't exist
-				roleToObjectPatternMapping[role] = []string{}
+			if !allowedResources[resource] {
+				continue
 			}
-			roleToObjectPatternMapping[role] = append(roleToObjectPatternMapping[role], objectPattern)
+
+			policy := roleToPolicyMapping[role]
+			if effect == "deny" {
+				// Deny patterns are matched per-application against the raw
+				// "<project>/<name>" object, so they keep their original
+				// "/*" suffix rather than being trimmed for SCAN prefixing.
+				policy.deny = append(policy.deny, objectPattern)
+			} else {
+				policy.allow = append(policy.allow, strings.TrimSuffix(objectPattern, "/*"))
+			}
+			roleToPolicyMapping[role] = policy
 		}
 	}
 
-	// Aggregate the user to object pattern mapping
-	userToObjectPatternMapping := make(map[string][]string)
-	for user, roles := range userToRoleMapping {
-		userToObjectPatternMapping[user] = []string{}
-
-		for _, role := range roles {
-			if objectPatterns, exists := roleToObjectPatternMapping[role]; exists {
-				userToObjectPatternMapping[user] = append(userToObjectPatternMapping[user], objectPatterns...)
+	aggregate := func(subjects []string) map[string]rbacPolicy {
+		result := make(map[string]rbacPolicy, len(subjects))
+		for _, subject := range subjects {
+			var policy rbacPolicy
+			for _, role := range resolveReachableRoles(subject, subjectEdges) {
+				rolePolicy, exists := roleToPolicyMapping[role]
+				if !exists {
+					continue
+				}
+				policy.allow = append(policy.allow, rolePolicy.allow...)
+				policy.deny = append(policy.deny, rolePolicy.deny...)
 			}
+			result[subject] = policy
 		}
+		return result
 	}
 
-	// Aggregate the group to object pattern mapping
-	groupToObjectPatternMapping := make(map[string][]string)
-	for group, roles := range groupToRoleMapping {
-		groupToObjectPatternMapping[group] = []string{}
-
-		for _, role := range roles {
-			if objectPatterns, exists := roleToObjectPatternMapping[role]; exists {
-				groupToObjectPatternMapping[group] = append(groupToObjectPatternMapping[group], objectPatterns...)
-			}
-		}
-	}
-	return userToObjectPatternMapping, groupToObjectPatternMapping
+	return aggregate(userSubjects), aggregate(groupSubjects)
 }

--- a/main.go
+++ b/main.go
@@ -14,10 +14,10 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
-	"path"
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -26,6 +26,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"github.com/go-redis/redis/v7"
+	"github.com/gobwas/glob"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -535,16 +536,38 @@ func filterRawByClusterAndNamespace(items [][]byte, cluster, namespace string) [
 	return filtered
 }
 
-// matchesObjectPattern reports whether object (typically "<project>/<name>")
-// matches an ArgoCD-style glob pattern. "*" is treated as matching everything,
-// including objects containing "/", which path.Match would otherwise reject
-// since "/" is a segment separator for it.
-func matchesObjectPattern(pattern, object string) bool {
-	if pattern == "*" {
-		return true
+// globCache memoizes compiled glob patterns; the same deny pattern is reused
+// across many requests (and many items within a request), so compiling once
+// per distinct pattern avoids recompiling on every call.
+var globCache sync.Map // map[string]glob.Glob
+
+// compileObjectGlob compiles pattern with no path separators configured, so
+// "*" matches across "/" just like ArgoCD's own RBAC enforcer (which uses
+// gobwas/glob the same way). This matters because deny patterns are matched
+// against "<project>/<name>" objects, and a pattern without an explicit "/"
+// (e.g. "team-*" instead of "team-*/*") must still be able to match through
+// the "/" to agree with ArgoCD's policy semantics.
+func compileObjectGlob(pattern string) (glob.Glob, error) {
+	if g, ok := globCache.Load(pattern); ok {
+		return g.(glob.Glob), nil
 	}
-	matched, err := path.Match(pattern, object)
-	return err == nil && matched
+	g, err := glob.Compile(pattern)
+	if err != nil {
+		return nil, err
+	}
+	globCache.Store(pattern, g)
+	return g, nil
+}
+
+// matchesObjectPattern reports whether object (typically "<project>/<name>")
+// matches an ArgoCD-style glob pattern.
+func matchesObjectPattern(pattern, object string) bool {
+	g, err := compileObjectGlob(pattern)
+	if err != nil {
+		log.Printf("Failed to compile object pattern %q: %v", pattern, err)
+		return false
+	}
+	return g.Match(object)
 }
 
 // excludeDenied removes applications matching any deny pattern from items.

--- a/main.go
+++ b/main.go
@@ -48,16 +48,12 @@ type rbacPolicy struct {
 	deny  []string
 }
 
-// allowedResources are the ArgoCD RBAC resource types that gate visibility of
-// items in the cached application list. Rules for other resource types (e.g.
-// "clusters", "certificates") don't affect which applications are returned by
-// this proxy, so they are ignored by parsePolicyCSV.
-var allowedResources = map[string]bool{
-	"applications":    true,
-	"applicationsets": true,
-	"logs":            true,
-	"exec":            true,
-}
+// applicationsResource is the only ArgoCD RBAC resource type that gates
+// visibility of items in the cached application list. The proxy only ever
+// serves /api/v1/applications, so "p" rules for other resource types (e.g.
+// "applicationsets", "logs", "exec", "clusters") are out of scope and ignored
+// by parsePolicyCSV.
+const applicationsResource = "applications"
 
 // Define Prometheus metrics for HTTP request duration (milliseconds) and total request count.
 var requestDuration = prometheus.NewHistogramVec(
@@ -632,9 +628,9 @@ func resolveReachableRoles(subject string, edges map[string][]string) []string {
 // "@") and one for groups. "g" lines are also used to build a generic
 // subject-to-role graph so role-to-role inheritance (e.g.
 // "g, role:org-admin, role:admin") is resolved transitively, not just one
-// level deep. Only "p" rules for resource types that affect application
-// visibility (allowedResources) contribute object patterns; rules for other
-// resource types (e.g. "clusters") are ignored.
+// level deep. Only "p" rules for the "applications" resource contribute
+// object patterns; rules for other resource types (e.g. "applicationsets",
+// "logs", "exec", "clusters") are out of scope for this proxy and ignored.
 func parsePolicyCSV(policyCSV string) (map[string]rbacPolicy, map[string]rbacPolicy) {
 	// subjectEdges records every "g, subject, role" edge. It doubles as the
 	// graph resolveReachableRoles walks for role-to-role inheritance, since a
@@ -691,7 +687,7 @@ func parsePolicyCSV(policyCSV string) (map[string]rbacPolicy, map[string]rbacPol
 				effect = strings.ToLower(fields[5])
 			}
 
-			if !allowedResources[resource] {
+			if resource != applicationsResource {
 				continue
 			}
 

--- a/main_test.go
+++ b/main_test.go
@@ -534,6 +534,8 @@ func TestMatchesObjectPattern(t *testing.T) {
 		{name: "Exact match", pattern: "myproj/myapp", object: "myproj/myapp", expected: true},
 		{name: "Prefix glob within project", pattern: "myproj/alpha-*", object: "myproj/alpha-1", expected: true},
 		{name: "Prefix glob does not match other prefix", pattern: "myproj/alpha-*", object: "myproj/beta-1", expected: false},
+		{name: "Wildcard without slash still matches across project/app boundary", pattern: "myproj-*", object: "myproj-team/myapp", expected: true},
+		{name: "Invalid pattern does not match", pattern: "[", object: "myproj/myapp", expected: false},
 	}
 
 	for _, tt := range tests {

--- a/main_test.go
+++ b/main_test.go
@@ -161,9 +161,12 @@ func TestParsePolicyCSV(t *testing.T) {
 			},
 		},
 		{
-			name: "Resource types unrelated to applications are ignored",
+			name: "Resource types other than applications are ignored",
 			policyCSV: `
 				p, team-alpha, clusters, get, https://example.com, allow
+				p, team-alpha, applicationsets, get, alpha-*, allow
+				p, team-alpha, logs, get, alpha-*, allow
+				p, team-alpha, exec, create, alpha-*, allow
 				g, alpha@gmail.com, team-alpha
 			`,
 			expectedUserToObjectPatternMapping: map[string]rbacPolicy{

--- a/main_test.go
+++ b/main_test.go
@@ -19,8 +19,8 @@ func TestParsePolicyCSV(t *testing.T) {
 	tests := []struct {
 		name                                string
 		policyCSV                           string
-		expectedUserToObjectPatternMapping  map[string][]string
-		expectedGroupToObjectPatternMapping map[string][]string
+		expectedUserToObjectPatternMapping  map[string]rbacPolicy
+		expectedGroupToObjectPatternMapping map[string]rbacPolicy
 	}{
 		{
 			name: "Valid policy CSV with single team ALPHA READ ONLY",
@@ -35,32 +35,23 @@ func TestParsePolicyCSV(t *testing.T) {
 				g, ALPHA READ ONLY_TW, team-alpha-readonly
 				g, foobar@gmail.com, team-alpha-readonly
 			`,
-			expectedUserToObjectPatternMapping: map[string][]string{
+			expectedUserToObjectPatternMapping: map[string]rbacPolicy{
 				"admin@gmail.com": {
-					"*",
+					allow: []string{"*"},
 				},
 				"admin@hotmail.com": {
-					"*",
+					allow: []string{"*"},
 				},
 				"foobar@gmail.com": {
-					"alpha1-*",
-					"alpha2-*",
-					"alpha3-*",
-					"alpha4-*",
+					allow: []string{"alpha1-*", "alpha2-*", "alpha3-*", "alpha4-*"},
 				},
 			},
-			expectedGroupToObjectPatternMapping: map[string][]string{
+			expectedGroupToObjectPatternMapping: map[string]rbacPolicy{
 				"ALPHA READ ONLY": {
-					"alpha1-*",
-					"alpha2-*",
-					"alpha3-*",
-					"alpha4-*",
+					allow: []string{"alpha1-*", "alpha2-*", "alpha3-*", "alpha4-*"},
 				},
 				"ALPHA READ ONLY_TW": {
-					"alpha1-*",
-					"alpha2-*",
-					"alpha3-*",
-					"alpha4-*",
+					allow: []string{"alpha1-*", "alpha2-*", "alpha3-*", "alpha4-*"},
 				},
 			},
 		},
@@ -79,33 +70,29 @@ func TestParsePolicyCSV(t *testing.T) {
 				g, BETA READ ONLY_TW, team-beta-readonly
 				g, barfoo@gmail.com, team-beta-readonly
 			`,
-			expectedUserToObjectPatternMapping: map[string][]string{
+			expectedUserToObjectPatternMapping: map[string]rbacPolicy{
 				"admin@gmail.com": {
-					"*",
+					allow: []string{"*"},
 				},
 				"admin@hotmail.com": {
-					"*",
+					allow: []string{"*"},
 				},
 				"barfoo@gmail.com": {
-					"beta-*",
+					allow: []string{"beta-*"},
 				},
 			},
-			expectedGroupToObjectPatternMapping: map[string][]string{
+			expectedGroupToObjectPatternMapping: map[string]rbacPolicy{
 				"ALPHA READ ONLY": {
-					"alpha1-*",
-					"alpha2-*",
-					"alpha3-*",
+					allow: []string{"alpha1-*", "alpha2-*", "alpha3-*"},
 				},
 				"ALPHA READ ONLY_TW": {
-					"alpha1-*",
-					"alpha2-*",
-					"alpha3-*",
+					allow: []string{"alpha1-*", "alpha2-*", "alpha3-*"},
 				},
 				"BETA READ ONLY": {
-					"beta-*",
+					allow: []string{"beta-*"},
 				},
 				"BETA READ ONLY_TW": {
-					"beta-*",
+					allow: []string{"beta-*"},
 				},
 			},
 		},
@@ -114,8 +101,8 @@ func TestParsePolicyCSV(t *testing.T) {
 			policyCSV: `
 				g, GAMMA READ ONLY, team-gamma-readonly
 			`,
-			expectedUserToObjectPatternMapping: map[string][]string{},
-			expectedGroupToObjectPatternMapping: map[string][]string{
+			expectedUserToObjectPatternMapping: map[string]rbacPolicy{},
+			expectedGroupToObjectPatternMapping: map[string]rbacPolicy{
 				"GAMMA READ ONLY": {},
 			},
 		},
@@ -124,21 +111,65 @@ func TestParsePolicyCSV(t *testing.T) {
 			policyCSV: `
 				p, team-gamma-readonly, applications, get, gamma-*, allow
 			`,
-			expectedUserToObjectPatternMapping:  map[string][]string{},
-			expectedGroupToObjectPatternMapping: map[string][]string{},
+			expectedUserToObjectPatternMapping:  map[string]rbacPolicy{},
+			expectedGroupToObjectPatternMapping: map[string]rbacPolicy{},
 		},
 		{
-			name: "Group name with quoted embedded comma is parsed as a single field",
+			name: "Deny effect overrides a broader allow pattern",
 			policyCSV: `
-				p, team-delta-readonly, applications, get, delta-*, allow
-				g, "cn=delta-readonly,ou=groups,dc=example,dc=com", team-delta-readonly
+				p, team-alpha, applications, get, alpha-*, allow
+				p, team-alpha, applications, get, alpha-secret/*, deny
+				g, alpha@gmail.com, team-alpha
 			`,
-			expectedUserToObjectPatternMapping: map[string][]string{},
-			expectedGroupToObjectPatternMapping: map[string][]string{
-				"cn=delta-readonly,ou=groups,dc=example,dc=com": {
-					"delta-*",
+			expectedUserToObjectPatternMapping: map[string]rbacPolicy{
+				"alpha@gmail.com": {
+					allow: []string{"alpha-*"},
+					deny:  []string{"alpha-secret/*"},
 				},
 			},
+			expectedGroupToObjectPatternMapping: map[string]rbacPolicy{},
+		},
+		{
+			name: "Quoted CSV field containing a comma",
+			policyCSV: `
+				p, team-ldap, applications, get, ldap-*, allow
+				g, "CN=Team Alpha,OU=Groups,DC=example,DC=com", team-ldap
+			`,
+			expectedUserToObjectPatternMapping: map[string]rbacPolicy{},
+			expectedGroupToObjectPatternMapping: map[string]rbacPolicy{
+				"CN=Team Alpha,OU=Groups,DC=example,DC=com": {
+					allow: []string{"ldap-*"},
+				},
+			},
+		},
+		{
+			name: "Role-to-role inheritance",
+			policyCSV: `
+				p, role:admin-base, applications, get, base-*, allow
+				g, role:org-admin, role:admin-base
+				g, admin@gmail.com, role:org-admin
+			`,
+			expectedUserToObjectPatternMapping: map[string]rbacPolicy{
+				"admin@gmail.com": {
+					allow: []string{"base-*"},
+				},
+			},
+			expectedGroupToObjectPatternMapping: map[string]rbacPolicy{
+				"role:org-admin": {
+					allow: []string{"base-*"},
+				},
+			},
+		},
+		{
+			name: "Resource types unrelated to applications are ignored",
+			policyCSV: `
+				p, team-alpha, clusters, get, https://example.com, allow
+				g, alpha@gmail.com, team-alpha
+			`,
+			expectedUserToObjectPatternMapping: map[string]rbacPolicy{
+				"alpha@gmail.com": {},
+			},
+			expectedGroupToObjectPatternMapping: map[string]rbacPolicy{},
 		},
 	}
 
@@ -146,10 +177,10 @@ func TestParsePolicyCSV(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			userToObjectPatternMapping, groupToObjectPatternMapping := parsePolicyCSV(tt.policyCSV)
 			if !reflect.DeepEqual(userToObjectPatternMapping, tt.expectedUserToObjectPatternMapping) {
-				t.Errorf("Expected user %v, but got user %v", tt.expectedUserToObjectPatternMapping, userToObjectPatternMapping)
+				t.Errorf("Expected user %+v, but got user %+v", tt.expectedUserToObjectPatternMapping, userToObjectPatternMapping)
 			}
 			if !reflect.DeepEqual(groupToObjectPatternMapping, tt.expectedGroupToObjectPatternMapping) {
-				t.Errorf("Expected group %v, but got group %v", tt.expectedGroupToObjectPatternMapping, groupToObjectPatternMapping)
+				t.Errorf("Expected group %+v, but got group %+v", tt.expectedGroupToObjectPatternMapping, groupToObjectPatternMapping)
 			}
 		})
 	}
@@ -160,19 +191,20 @@ func TestResolveObjectPatterns(t *testing.T) {
 		name                        string
 		email                       string
 		groups                      []string
-		userToObjectPatternMapping  map[string][]string
-		groupToObjectPatternMapping map[string][]string
-		expectedPatterns            map[string]struct{}
+		userToObjectPatternMapping  map[string]rbacPolicy
+		groupToObjectPatternMapping map[string]rbacPolicy
+		expectedAllow               map[string]struct{}
+		expectedDeny                []string
 	}{
 		{
 			name:   "User with direct patterns",
 			email:  "user1@example.com",
 			groups: []string{},
-			userToObjectPatternMapping: map[string][]string{
-				"user1@example.com": {"pattern1", "pattern2"},
+			userToObjectPatternMapping: map[string]rbacPolicy{
+				"user1@example.com": {allow: []string{"pattern1", "pattern2"}},
 			},
-			groupToObjectPatternMapping: map[string][]string{},
-			expectedPatterns: map[string]struct{}{
+			groupToObjectPatternMapping: map[string]rbacPolicy{},
+			expectedAllow: map[string]struct{}{
 				"pattern1": {},
 				"pattern2": {},
 			},
@@ -181,13 +213,13 @@ func TestResolveObjectPatterns(t *testing.T) {
 			name:   "Group with patterns",
 			email:  "user2@example.com",
 			groups: []string{"group1"},
-			userToObjectPatternMapping: map[string][]string{
+			userToObjectPatternMapping: map[string]rbacPolicy{
 				"user2@example.com": {},
 			},
-			groupToObjectPatternMapping: map[string][]string{
-				"group1": {"pattern3", "pattern4"},
+			groupToObjectPatternMapping: map[string]rbacPolicy{
+				"group1": {allow: []string{"pattern3", "pattern4"}},
 			},
-			expectedPatterns: map[string]struct{}{
+			expectedAllow: map[string]struct{}{
 				"pattern3": {},
 				"pattern4": {},
 			},
@@ -196,14 +228,14 @@ func TestResolveObjectPatterns(t *testing.T) {
 			name:   "User and groups with patterns",
 			email:  "user3@example.com",
 			groups: []string{"group1", "group2"},
-			userToObjectPatternMapping: map[string][]string{
-				"user3@example.com": {"pattern5"},
+			userToObjectPatternMapping: map[string]rbacPolicy{
+				"user3@example.com": {allow: []string{"pattern5"}},
 			},
-			groupToObjectPatternMapping: map[string][]string{
-				"group1": {"pattern6"},
-				"group2": {"pattern7"},
+			groupToObjectPatternMapping: map[string]rbacPolicy{
+				"group1": {allow: []string{"pattern6"}},
+				"group2": {allow: []string{"pattern7"}},
 			},
-			expectedPatterns: map[string]struct{}{
+			expectedAllow: map[string]struct{}{
 				"pattern5": {},
 				"pattern6": {},
 				"pattern7": {},
@@ -213,18 +245,37 @@ func TestResolveObjectPatterns(t *testing.T) {
 			name:                        "No patterns for user or groups",
 			email:                       "user4@example.com",
 			groups:                      []string{"group3"},
-			userToObjectPatternMapping:  map[string][]string{},
-			groupToObjectPatternMapping: map[string][]string{},
-			expectedPatterns:            map[string]struct{}{},
+			userToObjectPatternMapping:  map[string]rbacPolicy{},
+			groupToObjectPatternMapping: map[string]rbacPolicy{},
+			expectedAllow:               map[string]struct{}{},
+		},
+		{
+			name:   "Deny patterns are collected from both user and group policies",
+			email:  "user5@example.com",
+			groups: []string{"group1"},
+			userToObjectPatternMapping: map[string]rbacPolicy{
+				"user5@example.com": {allow: []string{"pattern1"}, deny: []string{"pattern1-secret/*"}},
+			},
+			groupToObjectPatternMapping: map[string]rbacPolicy{
+				"group1": {allow: []string{"pattern2"}, deny: []string{"pattern2-secret/*"}},
+			},
+			expectedAllow: map[string]struct{}{
+				"pattern1": {},
+				"pattern2": {},
+			},
+			expectedDeny: []string{"pattern1-secret/*", "pattern2-secret/*"},
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result := resolveObjectPatterns(tt.email, tt.groups, tt.userToObjectPatternMapping, tt.groupToObjectPatternMapping)
+			allow, deny := resolveObjectPatterns(tt.email, tt.groups, tt.userToObjectPatternMapping, tt.groupToObjectPatternMapping)
 
-			if !reflect.DeepEqual(result, tt.expectedPatterns) {
-				t.Errorf("resolveObjectPatterns() = %v, want %v", result, tt.expectedPatterns)
+			if !reflect.DeepEqual(allow, tt.expectedAllow) {
+				t.Errorf("resolveObjectPatterns() allow = %v, want %v", allow, tt.expectedAllow)
+			}
+			if !reflect.DeepEqual(deny, tt.expectedDeny) {
+				t.Errorf("resolveObjectPatterns() deny = %v, want %v", deny, tt.expectedDeny)
 			}
 		})
 	}
@@ -464,6 +515,98 @@ func TestFilterRawByClusterAndNamespace(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestMatchesObjectPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		pattern  string
+		object   string
+		expected bool
+	}{
+		{name: "Bare wildcard matches any object", pattern: "*", object: "myproj/myapp", expected: true},
+		{name: "Project wildcard matches app in project", pattern: "myproj/*", object: "myproj/myapp", expected: true},
+		{name: "Project wildcard does not match other project", pattern: "myproj/*", object: "otherproj/myapp", expected: false},
+		{name: "Exact match", pattern: "myproj/myapp", object: "myproj/myapp", expected: true},
+		{name: "Prefix glob within project", pattern: "myproj/alpha-*", object: "myproj/alpha-1", expected: true},
+		{name: "Prefix glob does not match other prefix", pattern: "myproj/alpha-*", object: "myproj/beta-1", expected: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if result := matchesObjectPattern(tt.pattern, tt.object); result != tt.expected {
+				t.Errorf("matchesObjectPattern(%q, %q) = %v, want %v", tt.pattern, tt.object, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestExcludeDenied(t *testing.T) {
+	makeApp := func(project, name string) []byte {
+		b, _ := json.Marshal(map[string]interface{}{
+			"metadata": map[string]interface{}{"name": name},
+			"spec":     map[string]interface{}{"project": project},
+		})
+		return b
+	}
+
+	appA := makeApp("myproj", "alpha-1")
+	appB := makeApp("myproj", "alpha-secret")
+	appC := makeApp("myproj", "beta-1")
+
+	tests := []struct {
+		name         string
+		items        [][]byte
+		denyPatterns []string
+		expected     [][]byte
+	}{
+		{
+			name:         "Narrow deny within a broad allow",
+			items:        [][]byte{appA, appB, appC},
+			denyPatterns: []string{"myproj/alpha-secret"},
+			expected:     [][]byte{appA, appC},
+		},
+		{
+			name:         "Deny all via bare wildcard",
+			items:        [][]byte{appA, appB, appC},
+			denyPatterns: []string{"*"},
+			expected:     [][]byte{},
+		},
+		{
+			name:         "No deny patterns",
+			items:        [][]byte{appA, appB},
+			denyPatterns: nil,
+			expected:     [][]byte{appA, appB},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := excludeDenied(tt.items, tt.denyPatterns)
+			if len(result) != len(tt.expected) {
+				t.Errorf("excludeDenied() returned %d items, want %d", len(result), len(tt.expected))
+				return
+			}
+			for i, item := range result {
+				if !bytes.Equal(item, tt.expected[i]) {
+					t.Errorf("excludeDenied()[%d] = %s, want %s", i, item, tt.expected[i])
+				}
+			}
+		})
+	}
+}
+
+func TestResolveReachableRoles(t *testing.T) {
+	edges := map[string][]string{
+		"admin@gmail.com": {"role:org-admin"},
+		"role:org-admin":  {"role:admin-base", "role:org-admin"}, // self-edge to verify cycle safety
+	}
+
+	result := resolveReachableRoles("admin@gmail.com", edges)
+	expected := []string{"role:org-admin", "role:admin-base"}
+	if !reflect.DeepEqual(result, expected) {
+		t.Errorf("resolveReachableRoles() = %v, want %v", result, expected)
 	}
 }
 


### PR DESCRIPTION
## Summary

`policy.csv` parsing had two gaps compared to ArgoCD's own RBAC engine:

- **Deny effect was ignored.** Only `allow` rules were ever honored, so a `deny` rule in `policy.csv` had no effect on the cached list endpoint. Deny is now enforced as a post-fetch filter (`excludeDenied`) so it correctly overrides an overlapping `allow`, matching ArgoCD's `some(where (p.eft == allow)) && !some(where (p.eft == deny))` rule — including the case where a broad `allow` pattern and a narrower `deny` pattern don't textually overlap (e.g. `alpha-*` allowed, `alpha-secret/*` denied). Allow patterns keep their existing `/*`-trim for Redis SCAN prefixing; deny patterns keep their original suffix and are matched per-application against the raw `<project>/<name>` object via `matchesObjectPattern`.
- **No role-to-role inheritance.** `g, role:org-admin, role:admin` (a role granted to another role) was not resolved — only direct user/group → role assignments worked. Role assignment is now resolved transitively via a generic subject→role graph (`resolveReachableRoles`), with cycle protection so a misconfigured policy can't recurse infinitely.

Also fixes a latent bug found while making this change: any resource type's `p` rule (e.g. `clusters`, `certificates`) was leaking into the application-visibility patterns — the existing resource-type check only gated the `/*`-suffix trim, not whether the rule was included at all. Since this proxy only ever serves `/api/v1/applications`, visibility is now scoped to the `applications` resource only (`applicationsResource`); `p` rules for any other resource type (`applicationsets`, `logs`, `exec`, `clusters`, …) are out of scope and ignored.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (rewrote `TestParsePolicyCSV`/`TestResolveObjectPatterns` for the new `rbacPolicy` allow/deny types, added cases for deny-effect, role-to-role inheritance, and out-of-scope resource types; added `TestMatchesObjectPattern`, `TestExcludeDenied`, `TestResolveReachableRoles`)
- [x] `make fmt && make vet && make test && make build`
