### PR TITLE
Reassemble ArgoCD's chunked session-token cookie

### DIFF
--- a/main.go
+++ b/main.go
@@ -378,14 +378,58 @@ func extractGroups(payload map[string]interface{}) []string {
 	return groups
 }
 
+// tokenCookieName is the base cookie ArgoCD stores the session token in.
+const tokenCookieName = "argocd.token"
+
 func extractToken(r *http.Request) string {
 	if authHeader := r.Header.Get("Authorization"); strings.HasPrefix(authHeader, "Bearer ") {
 		return strings.TrimPrefix(authHeader, "Bearer ")
 	}
-	if cookie, err := r.Cookie("argocd.token"); err == nil {
-		return cookie.Value
+	return joinChunkedToken(r.Cookies())
+}
+
+// joinChunkedToken reconstructs a session token that ArgoCD may have split
+// across multiple cookies. When a token's value exceeds the ~4093-byte
+// per-cookie limit (common for SSO users carrying many group claims), ArgoCD's
+// server stores it as "<chunkCount>:<chunk0>" in the base "argocd.token" cookie
+// and the remaining chunks in "argocd.token-1", "argocd.token-2", ... A token
+// that fits in one cookie has no "<count>:" prefix. This mirrors ArgoCD's own
+// util/http.JoinCookies so the proxy verifies exactly the token the backend
+// would; a malformed or absent cookie yields "" so the caller falls back to
+// proxying the request unchanged. Returns "" when no token cookie is present.
+func joinChunkedToken(cookies []*http.Cookie) string {
+	chunks := make(map[string]string)
+	for _, c := range cookies {
+		if strings.HasPrefix(c.Name, tokenCookieName) {
+			chunks[c.Name] = c.Value
+		}
 	}
-	return ""
+
+	base, ok := chunks[tokenCookieName]
+	if !ok {
+		return ""
+	}
+
+	var sb strings.Builder
+	numChunks := 1
+	// A JWT never contains a colon, so a base value with one is the
+	// "<count>:<chunk0>" form ArgoCD writes for a split token.
+	switch parts := strings.SplitN(base, ":", 2); len(parts) {
+	case 1:
+		sb.WriteString(parts[0])
+	case 2:
+		n, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return ""
+		}
+		numChunks = n
+		sb.WriteString(parts[1])
+	}
+
+	for i := 1; i < numChunks; i++ {
+		sb.WriteString(chunks[fmt.Sprintf("%s-%d", tokenCookieName, i)])
+	}
+	return sb.String()
 }
 
 // verifyAndDecodeJWT verifies the token's HMAC signature against signingKey

--- a/main_test.go
+++ b/main_test.go
@@ -325,6 +325,50 @@ func TestExtractToken(t *testing.T) {
 			},
 			expectedToken: "",
 		},
+		{
+			name: "Chunked token reassembled from multiple cookies",
+			setupRequest: func() *http.Request {
+				// ArgoCD splits a large token: the base cookie holds
+				// "<chunkCount>:<chunk0>" and the rest go in argocd.token-1, -2...
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.AddCookie(&http.Cookie{Name: "argocd.token", Value: "3:aaa"})
+				req.AddCookie(&http.Cookie{Name: "argocd.token-1", Value: "bbb"})
+				req.AddCookie(&http.Cookie{Name: "argocd.token-2", Value: "ccc"})
+				return req
+			},
+			expectedToken: "aaabbbccc",
+		},
+		{
+			name: "Chunked token reassembled regardless of cookie order",
+			setupRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.AddCookie(&http.Cookie{Name: "argocd.token-2", Value: "ccc"})
+				req.AddCookie(&http.Cookie{Name: "argocd.token", Value: "3:aaa"})
+				req.AddCookie(&http.Cookie{Name: "argocd.token-1", Value: "bbb"})
+				return req
+			},
+			expectedToken: "aaabbbccc",
+		},
+		{
+			name: "Authorization header wins over chunked cookies",
+			setupRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.Header.Set("Authorization", "Bearer header_token")
+				req.AddCookie(&http.Cookie{Name: "argocd.token", Value: "2:aaa"})
+				req.AddCookie(&http.Cookie{Name: "argocd.token-1", Value: "bbb"})
+				return req
+			},
+			expectedToken: "header_token",
+		},
+		{
+			name: "Malformed chunk count yields empty token",
+			setupRequest: func() *http.Request {
+				req := httptest.NewRequest(http.MethodGet, "/", nil)
+				req.AddCookie(&http.Cookie{Name: "argocd.token", Value: "notanumber:aaa"})
+				return req
+			},
+			expectedToken: "",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

ArgoCD's server splits a session token whose value exceeds the browser's ~4093-byte per-cookie limit across multiple cookies:

- the base `argocd.token` cookie holds `<chunkCount>:<chunk0>`
- the remaining chunks live in `argocd.token-1`, `argocd.token-2`, …

This is common for SSO users who carry many group claims.

`extractToken` previously read only the base `argocd.token` cookie. For these users the value was the truncated `<count>:<chunk0>` fragment, so JWT verification failed and the request silently fell back to proxying to the backend — losing the cached list-applications fast path for exactly the heaviest users (large group lists also mean the RBAC filtering matters most).

## Change

Reconstruct the full token from all chunks in `joinChunkedToken`, mirroring ArgoCD's own [`util/http.JoinCookies`](https://github.com/argoproj/argo-cd/blob/master/util/http/http.go), so the proxy verifies exactly the token the backend would.

- A token that fits in one cookie (no `<count>:` prefix) is returned unchanged.
- Chunks are reassembled by index regardless of cookie ordering.
- A malformed or absent token cookie yields an empty token, so the request falls back to proxying unchanged (same safe behavior as before).
- The `Authorization: Bearer` header still takes precedence over cookies.

## Tests

Extended `TestExtractToken` with cases for multi-chunk reassembly, out-of-order cookies, header precedence over chunked cookies, and malformed chunk counts. Full suite and `go vet` pass.